### PR TITLE
Fix round-off error in representation of date and time values

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -60,7 +60,7 @@ func (f *File) SetCellValue(sheet, axis string, value interface{}) {
 	case []byte:
 		f.SetCellStr(sheet, axis, string(t))
 	case time.Time:
-		f.SetCellDefault(sheet, axis, strconv.FormatFloat(float64(timeToExcelTime(timeToUTCTime(value.(time.Time)))), 'f', -1, 32))
+		f.SetCellDefault(sheet, axis, strconv.FormatFloat(float64(timeToExcelTime(timeToUTCTime(value.(time.Time)))), 'f', -1, 64))
 		f.setDefaultTimeStyle(sheet, axis)
 	case nil:
 		f.SetCellStr(sheet, axis, "")


### PR DESCRIPTION
Hi, it is an attempt to fix a round-off error of date and time valued cells set in time.Time. The following snippet demonstrates how to reproduce to the issue. Thanks!

```
package main

import (
	"github.com/360EntSecGroup-Skylar/excelize"
	"log"
	"time"
)

func main() {
	xlsx := excelize.NewFile()
	// 1970/01/01 1:00:00, but rounded off to 1970/1/1 0:59:02
	xlsx.SetCellValue("Sheet1", "A1", time.Date(1970, time.January, 1, 1, 0, 0, 0, time.UTC))
	err := xlsx.SaveAs("test.xlsx")
	if err != nil {
		log.Fatal(err)
	}
}
```
