### PR TITLE
CopySheet() using reflect instead of encoding/gob

### DIFF
--- a/excelize_test.go
+++ b/excelize_test.go
@@ -88,7 +88,6 @@ func TestOpenFile(t *testing.T) {
 	xlsx.SetCellValue("Sheet2", "F16", true)
 	xlsx.SetCellValue("Sheet2", "F17", complex64(5+10i))
 	t.Log(letterOnlyMapF('x'))
-	t.Log(deepCopy(nil, nil))
 	shiftJulianToNoon(1, -0.6)
 	timeFromExcelTime(61, true)
 	timeFromExcelTime(62, true)

--- a/lib.go
+++ b/lib.go
@@ -3,7 +3,6 @@ package excelize
 import (
 	"archive/zip"
 	"bytes"
-	"encoding/gob"
 	"io"
 	"log"
 	"math"
@@ -113,17 +112,6 @@ func intOnlyMapF(rune rune) rune {
 		return rune
 	}
 	return -1
-}
-
-// deepCopy provides method to creates a deep copy of whatever is passed to it
-// and returns the copy in an interface. The returned value will need to be
-// asserted to the correct type.
-func deepCopy(dst, src interface{}) error {
-	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(src); err != nil {
-		return err
-	}
-	return gob.NewDecoder(bytes.NewBuffer(buf.Bytes())).Decode(dst)
 }
 
 // boolPtr returns a pointer to a bool with the given value.


### PR DESCRIPTION
Use [github.com/mohae/deepcopy](https://godoc.org/github.com/mohae/deepcopy#Copy) (license MIT) to deep copy worksheets with package `reflect` instead of the internal [`deepcopy` function](https://github.com/360EntSecGroup-Skylar/excelize/blob/88e48e079a91191e05f32a232f8dec4454b25238/lib.go#L114L123) that was using `encoding/gob` serialization and
deserialization.