### PR TITLE
SheetViewOptionPtr: document that it is a superset of SheetViewOption

### DIFF
--- a/sheetview.go
+++ b/sheetview.go
@@ -9,6 +9,7 @@ type SheetViewOption interface {
 
 // SheetViewOptionPtr is a writable SheetViewOption. See GetSheetViewOptions().
 type SheetViewOptionPtr interface {
+	SheetViewOption
 	getSheetViewOption(view *xlsxSheetView)
 }
 

--- a/sheetview_test.go
+++ b/sheetview_test.go
@@ -13,6 +13,12 @@ var _ = []excelize.SheetViewOption{
 	excelize.ShowFormulas(false),
 	excelize.ShowGridLines(true),
 	excelize.ShowRowColHeaders(true),
+	// SheetViewOptionPtr are also SheetViewOption
+	new(excelize.DefaultGridColor),
+	new(excelize.RightToLeft),
+	new(excelize.ShowFormulas),
+	new(excelize.ShowGridLines),
+	new(excelize.ShowRowColHeaders),
 }
 
 var _ = []excelize.SheetViewOptionPtr{


### PR DESCRIPTION
Document in type system (not just in text for humans) that all SheetViewOptionPtr are also SheetViewOption (well, if not `nil`).
This improves documentation visible with godoc but this simple change also allows more flexibility to manipulate SheetViewOption programatically such as saving and restoring values as a `SheetViewOptionPtr` can now be used both with `SetSheetViewOption` as well as with `GetSheetView`:

```go
var opt excelize.ShowFormulas
opt = new(excelize.ShowFormulas)
_ = xl.GetSheetViewOptions(sheet, -1, opt)
_ = xl.SetSheetViewOptions(sheet, -1, opt)
```