### PR TITLE
Use min/mid/max value for 2 and 3 color scale conditional formatting

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -2674,12 +2674,25 @@ func drawCondFmtDuplicateUniqueValues(p int, ct string, format *formatConditiona
 // for color scale (include 2 color scale and 3 color scale) by given priority,
 // criteria type and format settings.
 func drawCondFmtColorScale(p int, ct string, format *formatConditional) *xlsxCfRule {
+	minValue := format.MinValue
+	if minValue == "" {
+		minValue = "0"
+	}
+	maxValue := format.MaxValue
+	if maxValue == "" {
+		maxValue = "0"
+	}
+	midValue := format.MidValue
+	if midValue == "" {
+		midValue = "50"
+	}
+
 	c := &xlsxCfRule{
 		Priority: p + 1,
 		Type:     "colorScale",
 		ColorScale: &xlsxColorScale{
 			Cfvo: []*xlsxCfvo{
-				{Type: format.MinType},
+				{Type: format.MinType, Val: minValue},
 			},
 			Color: []*xlsxColor{
 				{RGB: getPaletteColor(format.MinColor)},
@@ -2687,10 +2700,10 @@ func drawCondFmtColorScale(p int, ct string, format *formatConditional) *xlsxCfR
 		},
 	}
 	if validType[format.Type] == "3_color_scale" {
-		c.ColorScale.Cfvo = append(c.ColorScale.Cfvo, &xlsxCfvo{Type: format.MidType, Val: 50})
+		c.ColorScale.Cfvo = append(c.ColorScale.Cfvo, &xlsxCfvo{Type: format.MidType, Val: midValue})
 		c.ColorScale.Color = append(c.ColorScale.Color, &xlsxColor{RGB: getPaletteColor(format.MidColor)})
 	}
-	c.ColorScale.Cfvo = append(c.ColorScale.Cfvo, &xlsxCfvo{Type: format.MaxType})
+	c.ColorScale.Cfvo = append(c.ColorScale.Cfvo, &xlsxCfvo{Type: format.MaxType, Val: maxValue})
 	c.ColorScale.Color = append(c.ColorScale.Color, &xlsxColor{RGB: getPaletteColor(format.MaxColor)})
 	return c
 }

--- a/styles_test.go
+++ b/styles_test.go
@@ -1,0 +1,134 @@
+package excelize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetConditionalFormat(t *testing.T) {
+	cases := []struct {
+		label  string
+		format string
+		rules  []*xlsxCfRule
+	}{{
+		label: "3_color_scale",
+		format: `[{
+			"type":"3_color_scale",
+			"criteria":"=",
+			"min_type":"num",
+			"mid_type":"num",
+			"max_type":"num",
+			"min_value": "-10",
+			"mid_value": "0",
+			"max_value": "10",
+			"min_color":"ff0000",
+			"mid_color":"00ff00",
+			"max_color":"0000ff"
+		}]`,
+		rules: []*xlsxCfRule{{
+			Priority: 1,
+			Type:     "colorScale",
+			ColorScale: &xlsxColorScale{
+				Cfvo: []*xlsxCfvo{{
+					Type: "num",
+					Val:  -10,
+				}, {
+					Type: "num",
+					Val:  0,
+				}, {
+					Type: "num",
+					Val:  10,
+				}},
+				Color: []*xlsxColor{{
+					RGB: "FFFF0000",
+				}, {
+					RGB: "FF00FF00",
+				}, {
+					RGB: "FF0000FF",
+				}},
+			},
+		}},
+	}, {
+		label: "3_color_scale default min/mid/max",
+		format: `[{
+			"type":"3_color_scale",
+			"criteria":"=",
+			"min_type":"num",
+			"mid_type":"num",
+			"max_type":"num",
+			"min_color":"ff0000",
+			"mid_color":"00ff00",
+			"max_color":"0000ff"
+		}]`,
+		rules: []*xlsxCfRule{{
+			Priority: 1,
+			Type:     "colorScale",
+			ColorScale: &xlsxColorScale{
+				Cfvo: []*xlsxCfvo{{
+					Type: "num",
+					Val:  0,
+				}, {
+					Type: "num",
+					Val:  50,
+				}, {
+					Type: "num",
+					Val:  0,
+				}},
+				Color: []*xlsxColor{{
+					RGB: "FFFF0000",
+				}, {
+					RGB: "FF00FF00",
+				}, {
+					RGB: "FF0000FF",
+				}},
+			},
+		}},
+	}, {
+		label: "2_color_scale default min/max",
+		format: `[{
+			"type":"2_color_scale",
+			"criteria":"=",
+			"min_type":"num",
+			"max_type":"num",
+			"min_color":"ff0000",
+			"max_color":"0000ff"
+		}]`,
+		rules: []*xlsxCfRule{{
+			Priority: 1,
+			Type:     "colorScale",
+			ColorScale: &xlsxColorScale{
+				Cfvo: []*xlsxCfvo{{
+					Type: "num",
+					Val:  0,
+				}, {
+					Type: "num",
+					Val:  0,
+				}},
+				Color: []*xlsxColor{{
+					RGB: "FFFF0000",
+				}, {
+					RGB: "FF0000FF",
+				}},
+			},
+		}},
+	}}
+
+	for _, testCase := range cases {
+		xl := NewFile()
+		const sheet = "Sheet1"
+		const cellRange = "A1:A1"
+
+		err := xl.SetConditionalFormat(sheet, cellRange, testCase.format)
+		if err != nil {
+			t.Fatalf("%s", err)
+		}
+
+		xlsx := xl.workSheetReader(sheet)
+		cf := xlsx.ConditionalFormatting
+		assert.Len(t, cf, 1, testCase.label)
+		assert.Len(t, cf[0].CfRule, 1, testCase.label)
+		assert.Equal(t, cellRange, cf[0].SQRef, testCase.label)
+		assert.EqualValues(t, testCase.rules, cf[0].CfRule, testCase.label)
+	}
+}

--- a/styles_test.go
+++ b/styles_test.go
@@ -32,13 +32,13 @@ func TestSetConditionalFormat(t *testing.T) {
 			ColorScale: &xlsxColorScale{
 				Cfvo: []*xlsxCfvo{{
 					Type: "num",
-					Val:  -10,
+					Val:  "-10",
 				}, {
 					Type: "num",
-					Val:  0,
+					Val:  "0",
 				}, {
 					Type: "num",
-					Val:  10,
+					Val:  "10",
 				}},
 				Color: []*xlsxColor{{
 					RGB: "FFFF0000",
@@ -67,13 +67,13 @@ func TestSetConditionalFormat(t *testing.T) {
 			ColorScale: &xlsxColorScale{
 				Cfvo: []*xlsxCfvo{{
 					Type: "num",
-					Val:  0,
+					Val:  "0",
 				}, {
 					Type: "num",
-					Val:  50,
+					Val:  "50",
 				}, {
 					Type: "num",
-					Val:  0,
+					Val:  "0",
 				}},
 				Color: []*xlsxColor{{
 					RGB: "FFFF0000",
@@ -100,10 +100,10 @@ func TestSetConditionalFormat(t *testing.T) {
 			ColorScale: &xlsxColorScale{
 				Cfvo: []*xlsxCfvo{{
 					Type: "num",
-					Val:  0,
+					Val:  "0",
 				}, {
 					Type: "num",
-					Val:  0,
+					Val:  "0",
 				}},
 				Color: []*xlsxColor{{
 					RGB: "FFFF0000",

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -446,7 +446,7 @@ type xlsxIconSet struct {
 type xlsxCfvo struct {
 	Gte    bool        `xml:"gte,attr,omitempty"`
 	Type   string      `xml:"type,attr,omitempty"`
-	Val    int         `xml:"val,attr"`
+	Val    string      `xml:"val,attr"`
 	ExtLst *xlsxExtLst `xml:"extLst"`
 }
 


### PR DESCRIPTION
Fixes #252 

Please let me know if there's another preferred approach for these additional unit tests. I needed to access internal methods and structs to write the tests the way I have, but I did not readily see another approach in existing tests.

I have maintained existing behavior if `mid_value`, `max_value`, or `min_value` are omitted, but these changes could impact any existing code where these values were provided in format strings as they previously had no effect.