### PR TITLE
data validation drop-down list use sqref cell  issue #268

### DIFF
--- a/datavalidation.go
+++ b/datavalidation.go
@@ -119,6 +119,18 @@ func (dd *DataValidation) SetRange(f1, f2 int, t DataValidationType, o DataValid
 	return nil
 }
 
+// SetSqrefDropList data validation list with current sheet cell rang
+func (dd *DataValidation) SetSqrefDropList(sqref string, isCurrentSheet bool) error {
+	if isCurrentSheet {
+		dd.Formula1 = sqref
+		dd.Type = convDataValidationType(typeList)
+		return nil
+	}
+
+	//isCurrentSheet = false   Cross-sheet sqref cell use extLst xml node  unrealized
+	return fmt.Errorf("Cross-sheet sqref cell  are not supported")
+}
+
 // SetSqref provides function to set data validation range in drop list.
 func (dd *DataValidation) SetSqref(sqref string) {
 	if dd.Sqref == "" {

--- a/datavalidation_test.go
+++ b/datavalidation_test.go
@@ -24,6 +24,14 @@ func TestDataValidation(t *testing.T) {
 	dvRange.SetDropList([]string{"1", "2", "3"})
 	xlsx.AddDataValidation("Sheet1", dvRange)
 
+	xlsx.SetCellStr("Sheet1", "E1", "E1")
+	xlsx.SetCellStr("Sheet1", "E2", "E2")
+	xlsx.SetCellStr("Sheet1", "E3", "E3")
+	dvRange = NewDataValidation(true)
+	dvRange.Sqref = "A7:B8"
+	dvRange.SetSqrefDropList("$E$1:$E$3", true)
+	xlsx.AddDataValidation("Sheet1", dvRange)
+
 	// Test write file to given path.
 	err := xlsx.SaveAs("./test/Book_data_validation.xlsx")
 	if err != nil {


### PR DESCRIPTION
# PR Details

data validation drop-down list use sqref cell 

## Description

I think SetDropList only uses the current situation. SetSqrefDropList is used to indicate that the cell in the current sheet or other sheet is referenced.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
