### PR TITLE
Add Support for WriteTo Buffer

### DIFF
--- a/excelize_test.go
+++ b/excelize_test.go
@@ -135,6 +135,10 @@ func TestOpenFile(t *testing.T) {
 	if err != nil {
 		t.Log(err)
 	}
+	_, err = xlsx.WriteToBuffer()
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func TestAddPicture(t *testing.T) {

--- a/file.go
+++ b/file.go
@@ -76,6 +76,15 @@ func (f *File) Write(w io.Writer) error {
 
 // WriteTo implements io.WriterTo to write the file.
 func (f *File) WriteTo(w io.Writer) (int64, error) {
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		return 0, err
+	}
+	return buf.WriteTo(w)
+}
+
+// WriteToBuffer provides a function to get bytes.Buffer from the saved file.
+func (f *File) WriteToBuffer() (*bytes.Buffer, error) {
 	buf := new(bytes.Buffer)
 	zw := zip.NewWriter(buf)
 	f.contentTypesWriter()
@@ -86,17 +95,12 @@ func (f *File) WriteTo(w io.Writer) (int64, error) {
 	for path, content := range f.XLSX {
 		fi, err := zw.Create(path)
 		if err != nil {
-			return 0, err
+			return buf, err
 		}
 		_, err = fi.Write(content)
 		if err != nil {
-			return 0, err
+			return buf, err
 		}
 	}
-	err := zw.Close()
-	if err != nil {
-		return 0, err
-	}
-
-	return buf.WriteTo(w)
+	return buf, zw.Close()
 }


### PR DESCRIPTION
# PR Details

export a new function that people can get byte.buffer with all of file content

## Description

In some situation, we have to save the excel to a cloud storage service such as the Ali OSS. Some of the SDK that is supported by the cloud doesn't support write action. So we need to give it a reader that can read all of the excel file's content.


## Related Issue

## Motivation and Context

## How Has This Been Tested

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
