### PR TITLE
Add support to flip outline summaries

### DIFF
--- a/sheetpr.go
+++ b/sheetpr.go
@@ -31,7 +31,25 @@ type (
 	FitToPage bool
 	// AutoPageBreaks is a SheetPrOption
 	AutoPageBreaks bool
+	// OutlineSummaryBelow is an outlinePr, within SheetPr option
+	OutlineSummaryBelow bool
 )
+
+func (o OutlineSummaryBelow) setSheetPrOption(pr *xlsxSheetPr) {
+	if pr.OutlinePr == nil {
+		pr.OutlinePr = new(xlsxOutlinePr)
+	}
+	pr.OutlinePr.SummaryBelow = bool(o)
+}
+
+func (o *OutlineSummaryBelow) getSheetPrOption(pr *xlsxSheetPr) {
+	// Excel default: true
+	if pr == nil || pr.OutlinePr == nil {
+		*o = true
+		return
+	}
+	*o = OutlineSummaryBelow(defaultTrue(&pr.OutlinePr.SummaryBelow))
+}
 
 func (o CodeName) setSheetPrOption(pr *xlsxSheetPr) {
 	pr.CodeName = string(o)
@@ -115,6 +133,7 @@ func (o *AutoPageBreaks) getSheetPrOption(pr *xlsxSheetPr) {
 //   Published(bool)
 //   FitToPage(bool)
 //   AutoPageBreaks(bool)
+//   OutlineSummaryBelow(bool)
 func (f *File) SetSheetPrOptions(name string, opts ...SheetPrOption) error {
 	sheet := f.workSheetReader(name)
 	pr := sheet.SheetPr
@@ -137,6 +156,7 @@ func (f *File) SetSheetPrOptions(name string, opts ...SheetPrOption) error {
 //   Published(bool)
 //   FitToPage(bool)
 //   AutoPageBreaks(bool)
+//   OutlineSummaryBelow(bool)
 func (f *File) GetSheetPrOptions(name string, opts ...SheetPrOptionPtr) error {
 	sheet := f.workSheetReader(name)
 	pr := sheet.SheetPr

--- a/sheetpr_test.go
+++ b/sheetpr_test.go
@@ -15,6 +15,7 @@ var _ = []excelize.SheetPrOption{
 	excelize.Published(false),
 	excelize.FitToPage(true),
 	excelize.AutoPageBreaks(true),
+	excelize.OutlineSummaryBelow(true),
 }
 
 var _ = []excelize.SheetPrOptionPtr{
@@ -23,6 +24,7 @@ var _ = []excelize.SheetPrOptionPtr{
 	(*excelize.Published)(nil),
 	(*excelize.FitToPage)(nil),
 	(*excelize.AutoPageBreaks)(nil),
+	(*excelize.OutlineSummaryBelow)(nil),
 }
 
 func ExampleFile_SetSheetPrOptions() {
@@ -35,6 +37,7 @@ func ExampleFile_SetSheetPrOptions() {
 		excelize.Published(false),
 		excelize.FitToPage(true),
 		excelize.AutoPageBreaks(true),
+		excelize.OutlineSummaryBelow(false),
 	); err != nil {
 		panic(err)
 	}
@@ -51,6 +54,7 @@ func ExampleFile_GetSheetPrOptions() {
 		published                         excelize.Published
 		fitToPage                         excelize.FitToPage
 		autoPageBreaks                    excelize.AutoPageBreaks
+		outlineSummaryBelow               excelize.OutlineSummaryBelow
 	)
 
 	if err := xl.GetSheetPrOptions(sheet,
@@ -59,6 +63,7 @@ func ExampleFile_GetSheetPrOptions() {
 		&published,
 		&fitToPage,
 		&autoPageBreaks,
+		&outlineSummaryBelow,
 	); err != nil {
 		panic(err)
 	}
@@ -68,6 +73,7 @@ func ExampleFile_GetSheetPrOptions() {
 	fmt.Println("- published:", published)
 	fmt.Println("- fitToPage:", fitToPage)
 	fmt.Println("- autoPageBreaks:", autoPageBreaks)
+	fmt.Println("- outlineSummaryBelow:", outlineSummaryBelow)
 	// Output:
 	// Defaults:
 	// - codeName: ""
@@ -75,6 +81,7 @@ func ExampleFile_GetSheetPrOptions() {
 	// - published: true
 	// - fitToPage: false
 	// - autoPageBreaks: false
+	// - outlineSummaryBelow: true
 }
 
 func TestSheetPrOptions(t *testing.T) {
@@ -88,6 +95,7 @@ func TestSheetPrOptions(t *testing.T) {
 		{new(excelize.Published), excelize.Published(false)},
 		{new(excelize.FitToPage), excelize.FitToPage(true)},
 		{new(excelize.AutoPageBreaks), excelize.AutoPageBreaks(true)},
+		{new(excelize.OutlineSummaryBelow), excelize.OutlineSummaryBelow(false)},
 	} {
 		opt := test.nonDefault
 		t.Logf("option %T", opt)

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -211,6 +211,13 @@ type xlsxSheetPr struct {
 	TransitionEntry                   bool             `xml:"transitionEntry,attr,omitempty"`
 	TabColor                          *xlsxTabColor    `xml:"tabColor,omitempty"`
 	PageSetUpPr                       *xlsxPageSetUpPr `xml:"pageSetUpPr,omitempty"`
+	OutlinePr                         *xlsxOutlinePr   `xml:"outlinePr,omitempty"`
+}
+
+// xlsxOutlinePr maps to the outlinePr element
+// SummaryBelow allows you to adjust the direction of grouper controls
+type xlsxOutlinePr struct {
+	SummaryBelow bool `xml:"summaryBelow,attr"`
 }
 
 // xlsxPageSetUpPr directly maps the pageSetupPr element in the namespace


### PR DESCRIPTION
Closes #304

# PR Details

<!--- Provide a general summary of your changes in the Title above -->
This allows setting a sheet PR to show outline summary expand boxes above instead of below.

## Description

<!--- Describe your changes in detail -->

Added a new sheet pr type `OutlineSummaryBelow` and added that to the sheet serialization. Updated the respective tests.

## Related Issue
#304 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

My users think the summary groupers look better this way.

## How Has This Been Tested
I generated an excel document with nested summary levels and verified that the groupers appeared above instead of below. I also updated unit tests.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
