### PR TITLE
Duplicate row

### DIFF
--- a/excelize.go
+++ b/excelize.go
@@ -238,15 +238,16 @@ func (f *File) adjustRowDimensions(xlsx *xlsxWorksheet, rowIndex, offset int) {
 	}
 	for i, r := range xlsx.SheetData.Row {
 		if r.R >= rowIndex {
-			xlsx.SheetData.Row[i].R += offset
-			for k, v := range xlsx.SheetData.Row[i].C {
-				axis := v.R
-				col := string(strings.Map(letterOnlyMapF, axis))
-				row, _ := strconv.Atoi(strings.Map(intOnlyMapF, axis))
-				xAxis := row + offset
-				xlsx.SheetData.Row[i].C[k].R = col + strconv.Itoa(xAxis)
-			}
+			f.ajustSingleRowDimensions(&xlsx.SheetData.Row[i], offset)
 		}
+	}
+}
+
+func (f *File) ajustSingleRowDimensions(r *xlsxRow, offset int) {
+	r.R += offset
+	for i, col := range r.C {
+		row, _ := strconv.Atoi(strings.Map(intOnlyMapF, col.R))
+		r.C[i].R = string(strings.Map(letterOnlyMapF, col.R)) + strconv.Itoa(row+offset)
 	}
 }
 

--- a/excelize_test.go
+++ b/excelize_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOpenFile(t *testing.T) {
@@ -1027,6 +1029,71 @@ func TestInsertRow(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func TestDuplicateRow(t *testing.T) {
+	const (
+		file    = "./test/Book_DuplicateRow_%s.xlsx"
+		sheet   = "Sheet1"
+		a1      = "A1"
+		b1      = "B1"
+		a2      = "A2"
+		b2      = "B2"
+		a3      = "A3"
+		b3      = "B3"
+		a4      = "A4"
+		b4      = "B4"
+		a1Value = "A1 value"
+		a2Value = "A2 value"
+		a3Value = "A3 value"
+		bnValue = "Bn value"
+	)
+	xlsx := NewFile()
+	xlsx.SetCellStr(sheet, a1, a1Value)
+	xlsx.SetCellStr(sheet, b1, bnValue)
+
+	t.Run("FromSingleRow", func(t *testing.T) {
+		xlsx.DuplicateRow(sheet, 1)
+		xlsx.DuplicateRow(sheet, 2)
+
+		if assert.NoError(t, xlsx.SaveAs(fmt.Sprintf(file, "SignleRow"))) {
+			assert.Equal(t, a1Value, xlsx.GetCellValue(sheet, a1))
+			assert.Equal(t, a1Value, xlsx.GetCellValue(sheet, a2))
+			assert.Equal(t, a1Value, xlsx.GetCellValue(sheet, a3))
+			assert.Equal(t, bnValue, xlsx.GetCellValue(sheet, b1))
+			assert.Equal(t, bnValue, xlsx.GetCellValue(sheet, b2))
+			assert.Equal(t, bnValue, xlsx.GetCellValue(sheet, b3))
+		}
+	})
+
+	t.Run("UpdateDuplicatedRows", func(t *testing.T) {
+		xlsx.SetCellStr(sheet, a2, a2Value)
+		xlsx.SetCellStr(sheet, a3, a3Value)
+
+		if assert.NoError(t, xlsx.SaveAs(fmt.Sprintf(file, "Updated"))) {
+			assert.Equal(t, a1Value, xlsx.GetCellValue(sheet, a1))
+			assert.Equal(t, a2Value, xlsx.GetCellValue(sheet, a2))
+			assert.Equal(t, a3Value, xlsx.GetCellValue(sheet, a3))
+			assert.Equal(t, bnValue, xlsx.GetCellValue(sheet, b1))
+			assert.Equal(t, bnValue, xlsx.GetCellValue(sheet, b2))
+			assert.Equal(t, bnValue, xlsx.GetCellValue(sheet, b3))
+		}
+	})
+
+	t.Run("FromFirstOfMultipleRows", func(t *testing.T) {
+		xlsx.DuplicateRow(sheet, 1)
+
+		if assert.NoError(t, xlsx.SaveAs(fmt.Sprintf(file, "FirstOfMultipleRows"))) {
+			assert.Equal(t, a1Value, xlsx.GetCellValue(sheet, a1))
+			assert.Equal(t, a1Value, xlsx.GetCellValue(sheet, a2))
+			assert.Equal(t, a2Value, xlsx.GetCellValue(sheet, a3))
+			assert.Equal(t, a3Value, xlsx.GetCellValue(sheet, a4))
+			assert.Equal(t, bnValue, xlsx.GetCellValue(sheet, b1))
+			assert.Equal(t, bnValue, xlsx.GetCellValue(sheet, b2))
+			assert.Equal(t, bnValue, xlsx.GetCellValue(sheet, b3))
+			assert.Equal(t, bnValue, xlsx.GetCellValue(sheet, b4))
+		}
+	})
 }
 
 func TestSetPane(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,8 @@
 module github.com/360EntSecGroup-Skylar/excelize
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/rows.go
+++ b/rows.go
@@ -359,7 +359,7 @@ func (f *File) RemoveRow(sheet string, row int) {
 	}
 }
 
-// InsertRow provides a function to insert a new row before given row index.
+// InsertRow provides a function to insert a new row after given row index.
 // For example, create a new row before row 3 in Sheet1:
 //
 //    xlsx.InsertRow("Sheet1", 2)
@@ -370,6 +370,46 @@ func (f *File) InsertRow(sheet string, row int) {
 	}
 	row++
 	f.adjustHelper(sheet, -1, row, 1)
+}
+
+// DuplicateRow inserts a copy of specified row below specified
+//
+//    xlsx.DuplicateRow("Sheet1", 2)
+//
+func (f *File) DuplicateRow(sheet string, row int) {
+	if row < 0 {
+		return
+	}
+	row2 := row + 1
+	f.adjustHelper(sheet, -1, row2, 1)
+
+	xlsx := f.workSheetReader(sheet)
+	idx := -1
+	idx2 := -1
+
+	for i, r := range xlsx.SheetData.Row {
+		if r.R == row {
+			idx = i
+		} else if r.R == row2 {
+			idx2 = i
+		}
+		if idx != -1 && idx2 != -1 {
+			break
+		}
+	}
+
+	if idx == -1 || (idx2 == -1 && len(xlsx.SheetData.Row) >= row2) {
+		return
+	}
+	rowData := xlsx.SheetData.Row[idx]
+	cols := make([]xlsxC, 0, len(rowData.C))
+	rowData.C = append(cols, rowData.C...)
+	f.ajustSingleRowDimensions(&rowData, 1)
+	if idx2 != -1 {
+		xlsx.SheetData.Row[idx2] = rowData
+	} else {
+		xlsx.SheetData.Row = append(xlsx.SheetData.Row, rowData)
+	}
 }
 
 // checkRow provides a function to check and fill each column element for all


### PR DESCRIPTION
# PR Details

`File.DuplicateRow(sheet, row)` method added

## Description

`File.DuplicateRow(sheet, row)` method added, it is similar to `File.InsertRow(sheet, row)` but copies specified row values and styles. (Just like copy/paste in Excel).

Also subpart of code of `File.adjustRowDimensions()` method was extracted to separate method `File.ajustSingleRowDimensions()` and was reused in `DuplicateRow()`

## Related Issue

https://github.com/360EntSecGroup-Skylar/excelize/issues/83

## Motivation and Context

Motivation already described by another people in issue https://github.com/360EntSecGroup-Skylar/excelize/issues/83 — This enchantment required to use pre-created xlsx file as template.

## How Has This Been Tested

Related unit test added https://github.com/360EntSecGroup-Skylar/excelize/compare/master...albenik:duplicate_row?expand=1#diff-bd370461fa2f33b420b2ab991d34fa2cR1034 with subtests

`github.com/stretchr/testify` import introduced in test file, but this dependency where already preset as dependency in project. (Just run `G111MODULE=on go mod tidy` on master branch)

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. (But only autogenerated docs, same as for InsertRow() which not manually documented)
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
