### PR TITLE
Do not create a blank fill if no fill is specified in the style format

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -1907,9 +1907,11 @@ func (f *File) NewStyle(style string) (int, error) {
 	s.Borders.Border = append(s.Borders.Border, setBorders(fs))
 	borderID = s.Borders.Count - 1
 
-	s.Fills.Count++
-	s.Fills.Fill = append(s.Fills.Fill, setFills(fs, true))
-	fillID = s.Fills.Count - 1
+	if fill := setFills(fs, true); fill != nil {
+		s.Fills.Count++
+		s.Fills.Fill = append(s.Fills.Fill, fill)
+		fillID = s.Fills.Count - 1
+	}
 
 	applyAlignment, alignment := fs.Alignment != nil, setAlignment(fs)
 	applyProtection, protection := fs.Protection != nil, setProtection(fs)
@@ -2145,6 +2147,8 @@ func setFills(formatStyle *formatStyle, fg bool) *xlsxFill {
 			pattern.BgColor.RGB = getPaletteColor(formatStyle.Fill.Color[0])
 		}
 		fill.PatternFill = &pattern
+	default:
+		return nil
 	}
 	return &fill
 }

--- a/styles_test.go
+++ b/styles_test.go
@@ -6,6 +6,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestStyleFill(t *testing.T) {
+	cases := []struct {
+		label      string
+		format     string
+		expectFill bool
+	}{{
+		label:      "no_fill",
+		format:     `{"alignment":{"wrap_text":true}}`,
+		expectFill: false,
+	}, {
+		label:      "fill",
+		format:     `{"fill":{"type":"pattern","pattern":1,"color":["#000000"]}}`,
+		expectFill: true,
+	}}
+
+	for _, testCase := range cases {
+		xl := NewFile()
+		const sheet = "Sheet1"
+
+		styleID, err := xl.NewStyle(testCase.format)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		styles := xl.stylesReader()
+		style := styles.CellXfs.Xf[styleID]
+		if testCase.expectFill {
+			assert.NotEqual(t, style.FillID, 0, testCase.label)
+		} else {
+			assert.Equal(t, style.FillID, 0, testCase.label)
+		}
+	}
+}
+
 func TestSetConditionalFormat(t *testing.T) {
 	cases := []struct {
 		label  string


### PR DESCRIPTION
# PR Details

Do not create a blank fill if no fill is specified in the style format

## Description

setFills returns nil if type is not gradient or pattern.  NewStyle checks for nil and only adds fill / sets fillID if not nil.

## Related Issue

https://github.com/360EntSecGroup-Skylar/excelize/issues/331

## Motivation and Context

Setting a cell style on a cell that is part of a table overrides the table fill format regardless if there is a fill specified in the style format or not.  This only sets a fill on the style if provided a fill format in the call to NewStyle.

## How Has This Been Tested

Unit test added to styles_test.go for both a fill specified and fill not specified.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
