### PR TITLE
Faster TitleToNumber

### DIFF
--- a/excelize_test.go
+++ b/excelize_test.go
@@ -1546,8 +1546,12 @@ func TestConditionalFormatError(t *testing.T) {
 }
 
 func TestTitleToNumber(t *testing.T) {
+	assert.Equal(t, 0, TitleToNumber("A"))
+	assert.Equal(t, 25, TitleToNumber("Z"))
+	assert.Equal(t, 26, TitleToNumber("AA"))
 	assert.Equal(t, 36, TitleToNumber("AK"))
 	assert.Equal(t, 36, TitleToNumber("ak"))
+	assert.Equal(t, 51, TitleToNumber("AZ"))
 }
 
 func TestSharedStrings(t *testing.T) {

--- a/lib.go
+++ b/lib.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"io"
 	"log"
-	"math"
 	"strconv"
 	"strings"
 	"unicode"
@@ -91,15 +90,15 @@ func ToAlphaString(value int) string {
 //    excelize.TitleToNumber("ak")
 //
 func TitleToNumber(s string) int {
-	weight := 0.0
+	weight := 1
 	sum := 0
 	for i := len(s) - 1; i >= 0; i-- {
 		ch := int(s[i])
 		if int(s[i]) >= int('a') && int(s[i]) <= int('z') {
 			ch = int(s[i]) - 32
 		}
-		sum = sum + (ch-int('A')+1)*int(math.Pow(26, weight))
-		weight++
+		sum += (ch - int('A') + 1) * weight
+		weight *= 26
 	}
 	return sum - 1
 }

--- a/lib.go
+++ b/lib.go
@@ -93,11 +93,11 @@ func TitleToNumber(s string) int {
 	weight := 1
 	sum := 0
 	for i := len(s) - 1; i >= 0; i-- {
-		ch := int(s[i])
-		if int(s[i]) >= int('a') && int(s[i]) <= int('z') {
-			ch = int(s[i]) - 32
+		ch := s[i]
+		if ch >= 'a' && ch <= 'z' {
+			ch -= 32
 		}
-		sum += (ch - int('A') + 1) * weight
+		sum += int(ch-'A'+1) * weight
 		weight *= 26
 	}
 	return sum - 1


### PR DESCRIPTION
## Description

Simplify TitleToNumber implementation:
- add a few more test cases in `TestTitleToNumber`
- use pure integer computation (drop use of `math.Pow`)
- remove unnecessary casts to `int` 

## Motivation and Context

Faster TitleToNumber.

## How Has This Been Tested

Increased code coverage thanks to more test cases.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
