### PR TITLE
SetCellFloat to avoid numeric warnings in Excel

### DIFF
--- a/cell_test.go
+++ b/cell_test.go
@@ -36,3 +36,12 @@ func TestCheckCellInArea(t *testing.T) {
 			"Expected cell %v not to be inside of area %v, but got true\n", cell, area)
 	}
 }
+
+func TestSetCellFloat(t *testing.T) {
+	f := NewFile()
+	f.SetCellFloat("Sheet1", "A1", 123.01)
+	val := f.GetCellValue("Sheet1", "A1")
+	if val != "123.01" {
+		t.Errorf("Expected 123.01 but got %s", val)
+	}
+}

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -14,13 +14,13 @@ func ExampleFile_SetPageLayout() {
 	const sheet = "Sheet1"
 
 	if err := xl.SetPageLayout(
-		"Sheet1",
+		sheet,
 		excelize.PageLayoutOrientation(excelize.OrientationLandscape),
 	); err != nil {
 		panic(err)
 	}
 	if err := xl.SetPageLayout(
-		"Sheet1",
+		sheet,
 		excelize.PageLayoutPaperSize(10),
 	); err != nil {
 		panic(err)
@@ -35,10 +35,10 @@ func ExampleFile_GetPageLayout() {
 		orientation excelize.PageLayoutOrientation
 		paperSize   excelize.PageLayoutPaperSize
 	)
-	if err := xl.GetPageLayout("Sheet1", &orientation); err != nil {
+	if err := xl.GetPageLayout(sheet, &orientation); err != nil {
 		panic(err)
 	}
-	if err := xl.GetPageLayout("Sheet1", &paperSize); err != nil {
+	if err := xl.GetPageLayout(sheet, &paperSize); err != nil {
 		panic(err)
 	}
 	fmt.Println("Defaults:")

--- a/styles_test.go
+++ b/styles_test.go
@@ -23,7 +23,6 @@ func TestStyleFill(t *testing.T) {
 
 	for _, testCase := range cases {
 		xl := NewFile()
-		const sheet = "Sheet1"
 
 		styleID, err := xl.NewStyle(testCase.format)
 		if err != nil {


### PR DESCRIPTION
# PR Details

Excel will warn you if a string field holds a numeric value, this
allows the developer to avoid that warning.

Also removed duplicate type assertions in SetCellValue and
setCellIntValue.

## Related Issue

#357 

## Motivation and Context

My users were complaining about the little warning Excel gives if you put numeric values into a cell
as strings. This allowed me to properly set floating point values. Also, removing the duplicate type assertions should help performance.

## How Has This Been Tested

I added a unit test to make sure the value could still be retrieved using `GetCellValue`. I also integrated this change into my application using `gohack` and ensured it generated a valid xlsx document. I unzipped the document to make sure the xml looked like I would expect.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
