### PR TITLE
SetCellFloat for floats with specific precision

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -91,9 +91,9 @@ func (f *File) SetCellValue(sheet, axis string, value interface{}) {
 	case uint64:
 		f.SetCellInt(sheet, axis, int(v))
 	case float32:
-		f.SetCellDefault(sheet, axis, strconv.FormatFloat(float64(v), 'f', -1, 32))
+		f.SetCellFloat(sheet, axis, float64(v), -1, 32)
 	case float64:
-		f.SetCellDefault(sheet, axis, strconv.FormatFloat(v, 'f', -1, 64))
+		f.SetCellFloat(sheet, axis, v, -1, 64)
 	case string:
 		f.SetCellStr(sheet, axis, v)
 	case []byte:
@@ -140,6 +140,21 @@ func (f *File) SetCellBool(sheet, axis string, value bool) {
 	} else {
 		cellData.V = "0"
 	}
+}
+
+// SetCellFloat sets a floating point value into a cell. The prec parameter
+// specifies how many places after the decimal will be shown while -1
+// is a special value that will use as many decimal places as necessary to
+// represent the number. bitSize is 32 or 64 depending on if a float32 or float64
+// was originally used for the value
+//     var x float32 = 1.325
+//     f.SetCellFloat("Sheet1", "A1", float64(x), 2, 32)
+func (f *File) SetCellFloat(sheet, axis string, value float64, prec, bitSize int) {
+	xlsx := f.workSheetReader(sheet)
+	cellData, col, _ := f.prepareCell(xlsx, sheet, axis)
+	cellData.S = f.prepareCellStyle(xlsx, col, cellData.S)
+	cellData.T = ""
+	cellData.V = strconv.FormatFloat(value, 'f', prec, 64)
 }
 
 // SetCellStr provides a function to set string type value of a cell. Total

--- a/cell_test.go
+++ b/cell_test.go
@@ -1,6 +1,7 @@
 package excelize
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +39,35 @@ func TestCheckCellInArea(t *testing.T) {
 	assert.Panics(t, func() {
 		checkCellInArea("AA0", "Z0:AB1")
 	})
+}
+
+func TestSetCellFloat(t *testing.T) {
+	sheet := "Sheet1"
+	t.Run("with no decimal", func(t *testing.T) {
+		f := NewFile()
+		f.SetCellFloat(sheet, "A1", 123.0, -1, 64)
+		f.SetCellFloat(sheet, "A2", 123.0, 1, 64)
+		assert.Equal(t, "123", f.GetCellValue(sheet, "A1"), "A1 should be 123")
+		assert.Equal(t, "123.0", f.GetCellValue(sheet, "A2"), "A2 should be 123.0")
+	})
+
+	t.Run("with a decimal and precision limit", func(t *testing.T) {
+		f := NewFile()
+		f.SetCellFloat(sheet, "A1", 123.42, 1, 64)
+		assert.Equal(t, "123.4", f.GetCellValue(sheet, "A1"), "A1 should be 123.4")
+	})
+
+	t.Run("with a decimal and no limit", func(t *testing.T) {
+		f := NewFile()
+		f.SetCellFloat(sheet, "A1", 123.42, -1, 64)
+		assert.Equal(t, "123.42", f.GetCellValue(sheet, "A1"), "A1 should be 123.42")
+	})
+}
+
+func ExampleFile_SetCellFloat() {
+	f := NewFile()
+	var x float64 = 3.14159265
+	f.SetCellFloat("Sheet1", "A1", x, 2, 64)
+	fmt.Println(f.GetCellValue("Sheet1", "A1"))
+	// Output: 3.14
 }


### PR DESCRIPTION
# PR Details

## Description

This allows the user to set a floating point value into a
cell with a specific number of places after the decimal.

## Related Issue

#357 

## Motivation and Context

This allows people to cleanly put floating point values with the desired amount of precision into
a cell without having to round them manually.

## How Has This Been Tested

Added unit tests and integrated the changes into my application.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
