### PR TITLE
Added SetRowOutlineRangeLevel for range of rows

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -361,6 +361,18 @@ func (f *File) GetRowOutlineLevel(sheet string, row int) uint8 {
 	return xlsx.SheetData.Row[row-1].OutlineLevel
 }
 
+// SetRowOutlineRangeLevel provides a function to set outline level number of a
+// range of rows by giving worksheet name, start & end row index. For example, outline row
+// 2-10 in Sheet1 to level 1:
+//
+//    xlsx.SetRowOutlineRangeLevel("Sheet1", 2, 10, 1)
+//
+func (f *File) SetRowOutlineRangeLevel(sheet string, startRow int, endRow int, level uint8) {
+	for i := startRow; i <= endRow; i++ {
+		f.SetRowOutlineLevel(sheet, i, level)
+	}
+}
+
 // RemoveRow provides a function to remove single row by given worksheet name
 // and Excel row number. For example, remove row 3 in Sheet1:
 //


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Having an option for specifying the range of row numbers to be grouped in the same outline level.

## Related Issue

#362 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

It would allow users to specify the range of row numbers for the outline level to be applied instead of specifying it for every row.

## How Has This Been Tested

Tested it out locally.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
