### PR TITLE
Fixed PR #356 regression RemoveCol() broken

### DIFF
--- a/col.go
+++ b/col.go
@@ -337,11 +337,12 @@ func (f *File) RemoveCol(sheet, col string) {
 
 	xlsx := f.workSheetReader(sheet)
 	for rowIdx := range xlsx.SheetData.Row {
-		rowData := xlsx.SheetData.Row[rowIdx]
-		for colIdx, cellData := range rowData.C {
-			colName, _, _ := SplitCellName(cellData.R)
+		rowData := &xlsx.SheetData.Row[rowIdx]
+		for colIdx := range rowData.C {
+			colName, _, _ := SplitCellName(rowData.C[colIdx].R)
 			if colName == col {
-				rowData.C = append(rowData.C[:colIdx], rowData.C[colIdx+1:]...)
+				rowData.C = append(rowData.C[:colIdx], rowData.C[colIdx+1:]...)[:len(rowData.C)-1]
+				break
 			}
 		}
 	}

--- a/rows.go
+++ b/rows.go
@@ -379,9 +379,10 @@ func (f *File) RemoveRow(sheet string, row int) {
 	if row > len(xlsx.SheetData.Row) {
 		return
 	}
-	for i, r := range xlsx.SheetData.Row {
-		if r.R == row {
-			xlsx.SheetData.Row = append(xlsx.SheetData.Row[:i], xlsx.SheetData.Row[i+1:]...)
+	for rowIdx := range xlsx.SheetData.Row {
+		if xlsx.SheetData.Row[rowIdx].R == row {
+			xlsx.SheetData.Row = append(xlsx.SheetData.Row[:rowIdx],
+				xlsx.SheetData.Row[rowIdx+1:]...)[:len(xlsx.SheetData.Row)-1]
 			f.adjustHelper(sheet, rows, row, -1)
 			return
 		}


### PR DESCRIPTION
# PR Details

Fixed PR #356 regression RemoveCol() broken

## Description

After PR #356 `RemoveCol()` call leads to a broken excel file.
Also minor code style changes done to made `RemoveCol` & `RemoveRow` code style identical.

## Related Issue

PR #356 

## Motivation and Context

Bugfix

## How Has This Been Tested

Check resulting xslx file by hands in real-word project.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
