### PR TITLE
Add benchmark for adding images to sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 ~$*.xlsx
 test/Test*.xlsx
+*.out
+test/image3.png
+*.test

--- a/picture_test.go
+++ b/picture_test.go
@@ -1,0 +1,20 @@
+package excelize
+
+import (
+	"fmt"
+	_ "image/png"
+	"io/ioutil"
+	"testing"
+)
+
+func BenchmarkAddPictureFromBytes(b *testing.B) {
+	f := NewFile()
+	imgFile, err := ioutil.ReadFile("logo.png")
+	if err != nil {
+		panic("unable to load image for benchmark")
+	}
+	b.ResetTimer()
+	for i := 1; i <= b.N; i++ {
+		f.AddPictureFromBytes("Sheet1", fmt.Sprint("A", i), "", "logo", ".png", imgFile)
+	}
+}

--- a/sheet.go
+++ b/sheet.go
@@ -778,18 +778,20 @@ func (f *File) UnprotectSheet(sheet string) {
 // trimSheetName provides a function to trim invaild characters by given worksheet
 // name.
 func trimSheetName(name string) string {
-	var r []rune
-	for _, v := range name {
-		switch v {
-		case 58, 92, 47, 63, 42, 91, 93: // replace :\/?*[]
-			continue
-		default:
-			r = append(r, v)
+	if strings.ContainsAny(name, ":\\/?*[]") || utf8.RuneCountInString(name) > 31 {
+		r := make([]rune, 0, 31)
+		for _, v := range name {
+			switch v {
+			case 58, 92, 47, 63, 42, 91, 93: // replace :\/?*[]
+				continue
+			default:
+				r = append(r, v)
+			}
+			if len(r) == 31 {
+				break
+			}
 		}
-	}
-	name = string(r)
-	if utf8.RuneCountInString(name) > 31 {
-		name = string([]rune(name)[0:31])
+		name = string(r)
 	}
 	return name
 }


### PR DESCRIPTION
# PR Details

Benchmark image adding

## Description

This should help track performance regressions in future changes. I didn't want to start code to
reduce image duplication until I had a performance baseline.

Current output looks like this:
`BenchmarkAddPictureFromBytes-8   	   10000	   2205294 ns/op	  373361 B/op	   20358 allocs/op`

## Related Issue

#359 

## Motivation and Context

This is a first step towards future changes to this functionality.

## How Has This Been Tested

This is a test :)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
