### PR TITLE
fix: SetCellVal before using NewSheet will destroy the excel file

### DIFF
--- a/excelize.go
+++ b/excelize.go
@@ -113,9 +113,11 @@ func (f *File) setDefaultTimeStyle(sheet, axis string, format int) error {
 // workSheetReader provides a function to get the pointer to the structure
 // after deserialization by given worksheet name.
 func (f *File) workSheetReader(sheet string) *xlsxWorksheet {
-	name, ok := f.sheetMap[trimSheetName(sheet)]
+	trimdSheet := trimSheetName(sheet)
+	name, ok := f.sheetMap[trimdSheet]
 	if !ok {
-		name = "xl/worksheets/" + strings.ToLower(sheet) + ".xml"
+		f.NewSheet(sheet)
+		name, _ = f.sheetMap[trimdSheet]
 	}
 	if f.Sheet[name] == nil {
 		var xlsx xlsxWorksheet


### PR DESCRIPTION
# PR Details

SetCellVal before using NewSheet will destroy the excel file

## Description

like below

## Motivation and Context

## How Has This Been Tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

close #370