### PR TITLE
fix calc object position  for addPicture

### DIFF
--- a/col.go
+++ b/col.go
@@ -268,7 +268,7 @@ func (f *File) positionObjectPixels(sheet string, col, row, x1, y1, width, heigh
 	height += y1
 
 	// Subtract the underlying cell widths to find end cell of the object.
-	for width >= f.getColWidth(sheet, colEnd) {
+	for width >= f.getColWidth(sheet, colEnd + 1) {
 		colEnd++
 		width -= f.getColWidth(sheet, colEnd)
 	}

--- a/col.go
+++ b/col.go
@@ -275,8 +275,8 @@ func (f *File) positionObjectPixels(sheet string, col, row, x1, y1, width, heigh
 
 	// Subtract the underlying cell heights to find end cell of the object.
 	for height >= f.getRowHeight(sheet, rowEnd) {
-		rowEnd++
 		height -= f.getRowHeight(sheet, rowEnd)
+		rowEnd++
 	}
 
 	// The end vertices are whatever is left from the width and height.

--- a/col.go
+++ b/col.go
@@ -268,7 +268,7 @@ func (f *File) positionObjectPixels(sheet string, col, row, x1, y1, width, heigh
 	height += y1
 
 	// Subtract the underlying cell widths to find end cell of the object.
-	for width >= f.getColWidth(sheet, colEnd + 1) {
+	for width >= f.getColWidth(sheet, colEnd+1) {
 		colEnd++
 		width -= f.getColWidth(sheet, colEnd)
 	}


### PR DESCRIPTION
# PR Details

Fix calc object position for addPicture.

## Description

The target cell for calclator the width and height 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

I wanted to fix one of the factors that caused the size of the inserted image to be incorrect.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Verified by local excel()
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
