### PR TITLE
Fix two bugs related to Formula

### DIFF
--- a/calcchain.go
+++ b/calcchain.go
@@ -33,14 +33,12 @@ func (f *File) calcChainWriter() {
 
 // deleteCalcChain provides a function to remove cell reference on the
 // calculation chain.
-func (f *File) deleteCalcChain(axis string) {
+func (f *File) deleteCalcChain(index int, axis string) {
 	calc := f.calcChainReader()
 	if calc != nil {
-		for i, c := range calc.C {
-			if c.R == axis {
-				calc.C = append(calc.C[:i], calc.C[i+1:]...)
-			}
-		}
+		calc.C = xlsxCalcChainCollection(calc.C).Filter(func(c xlsxCalcChainC) bool {
+			return !((c.I == index && c.R == axis) || (c.I == index && axis == ""))
+		})
 	}
 	if len(calc.C) == 0 {
 		f.CalcChain = nil
@@ -52,4 +50,16 @@ func (f *File) deleteCalcChain(axis string) {
 			}
 		}
 	}
+}
+
+type xlsxCalcChainCollection []xlsxCalcChainC
+
+func (c xlsxCalcChainCollection) Filter(fn func(v xlsxCalcChainC) bool) []xlsxCalcChainC {
+	results := make([]xlsxCalcChainC, 0)
+	for _, v := range c {
+		if fn(v) {
+			results = append(results, v)
+		}
+	}
+	return results
 }

--- a/cell.go
+++ b/cell.go
@@ -235,7 +235,7 @@ func (f *File) SetCellFormula(sheet, axis, formula string) error {
 	}
 	if formula == "" {
 		cellData.F = nil
-		f.deleteCalcChain(axis)
+		f.deleteCalcChain(f.GetSheetIndex(sheet), axis)
 		return err
 	}
 

--- a/sheet.go
+++ b/sheet.go
@@ -403,6 +403,7 @@ func (f *File) DeleteSheet(name string) {
 			rels := "xl/worksheets/_rels/sheet" + strconv.Itoa(v.SheetID) + ".xml.rels"
 			target := f.deleteSheetFromWorkbookRels(v.ID)
 			f.deleteSheetFromContentTypes(target)
+			f.deleteCalcChain(v.SheetID, "") // Delete CalcChain
 			delete(f.sheetMap, name)
 			delete(f.XLSX, sheet)
 			delete(f.XLSX, rels)


### PR DESCRIPTION
# PR Details



## Description

### Bug 1

Out of range panic when removing formula.

#### Reproduction Steps

1. Download [input.xlsx](https://github.com/360EntSecGroup-Skylar/excelize/files/3059522/input.xlsx)
2. run following code.
```go
package main

import "github.com/360EntSecGroup-Skylar/excelize"

func main() {
	f, err := excelize.OpenFile("input.xlsx")
	if err != nil {
		panic(err)
	}
	f.SetCellFormula("Sheet1", "A1", "")
	if err := f.SaveAs("panic.xlsx"); err != nil {
		panic(err)
	}
}
```

#### Actual Behavior
```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/360EntSecGroup-Skylar/excelize.(*File).deleteCalcChain(0xc0000c61e0, 0x115c7d1, 0x2)
	/Users/aplulu/go/pkg/mod/github.com/360!ent!sec!group-!skylar/excelize@v1.4.2-0.20190407060441-4e7d93a77796/calcchain.go:41 +0x574
github.com/360EntSecGroup-Skylar/excelize.(*File).SetCellFormula(0xc0000c61e0, 0x115d631, 0x7, 0x115c7d1, 0x2, 0x0, 0x0, 0x10f5c9c, 0xc0000aff88)
	/Users/aplulu/go/pkg/mod/github.com/360!ent!sec!group-!skylar/excelize@v1.4.2-0.20190407060441-4e7d93a77796/cell.go:238 +0x108
main.main()
	/Users/aplulu/projects/excelize/test/bug/bug1.go:10 +0xa0
exit status 2
```

### Bug 2

If the deleted sheet contains Formula, file will be corrupted.

#### Reproduction Steps
1. Download [input.xlsx](https://github.com/360EntSecGroup-Skylar/excelize/files/3059522/input.xlsx)
2. Run following code.
3. Open the generated corrupt.xlsx in Excel.

```go
package main

import "github.com/360EntSecGroup-Skylar/excelize"

func main() {
	f, err := excelize.OpenFile("input.xlsx")
	if err != nil {
		panic(err)
	}
	f.DeleteSheet("Sheet2")
	if err := f.SaveAs("corrupt.xlsx"); err != nil {
		panic(err)
	}
}
```

#### Actual Behavior
![Screen Shot 2019-04-09 at 23 58 12](https://user-images.githubusercontent.com/20220680/55810997-651ea180-5b23-11e9-9437-0a10a2b8c302.png)

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<recoveryLog xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><logFileName>Repair Result to corrupt0.xml</logFileName><summary>Errors were detected in file '/Users/aplulu/projects/excelize/test/bug/corrupt.xlsx'</summary><removedRecords summary="Following is a list of removed records:"><removedRecord>Removed Records: Formula from /xl/calcChain.xml part (Calculation properties)</removedRecord></removedRecords></recoveryLog>
```

### Environement

* Excelize master branch
* go version go1.12.3 darwin/amd64
* Microsoft Excel for Mac version 16.23

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
