### PR TITLE
Rewrite prepareSheetXML to scale linearly

### DIFF
--- a/cell_test.go
+++ b/cell_test.go
@@ -82,3 +82,15 @@ func ExampleFile_SetCellFloat() {
 	fmt.Println(val)
 	// Output: 3.14
 }
+
+func BenchmarkSetCellValue(b *testing.B) {
+	values := []string{"First", "Second", "Third", "Fourth", "Fifth", "Sixth"}
+	cols := []string{"A", "B", "C", "D", "E", "F"}
+	f := NewFile()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < len(values); j++ {
+			f.SetCellValue("Sheet1", fmt.Sprint(cols[j], i), values[j])
+		}
+	}
+}

--- a/rows.go
+++ b/rows.go
@@ -419,7 +419,7 @@ func (f *File) InsertRow(sheet string, row int) error {
 	return f.adjustHelper(sheet, rows, row, 1)
 }
 
-// DuplicateRow inserts a copy of specified row (by it Excel row number) below
+// DuplicateRow inserts a copy of specified row (by its Excel row number) below
 //
 //    err := xlsx.DuplicateRow("Sheet1", 2)
 //

--- a/rows_test.go
+++ b/rows_test.go
@@ -59,11 +59,11 @@ func TestRowHeight(t *testing.T) {
 
 	assert.EqualError(t, xlsx.SetRowHeight(sheet1, 0, defaultRowHeightPixels+1.0), "invalid row number 0")
 
-	height, err := xlsx.GetRowHeight("Sheet1", 0)
+	_, err := xlsx.GetRowHeight("Sheet1", 0)
 	assert.EqualError(t, err, "invalid row number 0")
 
 	assert.NoError(t, xlsx.SetRowHeight(sheet1, 1, 111.0))
-	height, err = xlsx.GetRowHeight(sheet1, 1)
+	height, err := xlsx.GetRowHeight(sheet1, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 111.0, height)
 

--- a/sheet.go
+++ b/sheet.go
@@ -1068,7 +1068,6 @@ func fillColumns(rowData *xlsxRow, col, row int) {
 func makeContiguousColumns(xlsx *xlsxWorksheet, fromRow, toRow, colCount int) {
 	for ; fromRow < toRow; fromRow++ {
 		rowData := &xlsx.SheetData.Row[fromRow-1]
-		rowData.R = fromRow
 		fillColumns(rowData, colCount, fromRow)
 	}
 }

--- a/sheet.go
+++ b/sheet.go
@@ -1041,8 +1041,8 @@ func (f *File) workSheetRelsWriter() {
 	}
 }
 
-// fillSheetData fill missing row and cell XML data to made it continuous from
-// first cell [1, 1] to last cell [col, row]
+// fillSheetData ensures there are enough rows, and columns in the chosen
+// row to accept data. Missing rows are backfilled and given their row number
 func prepareSheetXML(xlsx *xlsxWorksheet, col int, row int) {
 	rowCount := len(xlsx.SheetData.Row)
 	if rowCount < row {
@@ -1051,14 +1051,24 @@ func prepareSheetXML(xlsx *xlsxWorksheet, col int, row int) {
 			xlsx.SheetData.Row = append(xlsx.SheetData.Row, xlsxRow{R: rowIdx + 1})
 		}
 	}
-	for rowIdx := range xlsx.SheetData.Row {
-		rowData := &xlsx.SheetData.Row[rowIdx] // take reference
-		cellCount := len(rowData.C)
-		if cellCount < col {
-			for colIdx := cellCount; colIdx < col; colIdx++ {
-				cellName, _ := CoordinatesToCellName(colIdx+1, rowIdx+1)
-				rowData.C = append(rowData.C, xlsxC{R: cellName})
-			}
+	rowData := &xlsx.SheetData.Row[row-1]
+	fillColumns(rowData, col, row)
+}
+
+func fillColumns(rowData *xlsxRow, col, row int) {
+	cellCount := len(rowData.C)
+	if cellCount < col {
+		for colIdx := cellCount; colIdx < col; colIdx++ {
+			cellName, _ := CoordinatesToCellName(colIdx+1, row)
+			rowData.C = append(rowData.C, xlsxC{R: cellName})
 		}
+	}
+}
+
+func makeContiguousColumns(xlsx *xlsxWorksheet, fromRow, toRow, colCount int) {
+	for ; fromRow < toRow; fromRow++ {
+		rowData := &xlsx.SheetData.Row[fromRow-1]
+		rowData.R = fromRow
+		fillColumns(rowData, colCount, fromRow)
 	}
 }

--- a/styles.go
+++ b/styles.go
@@ -2367,6 +2367,7 @@ func (f *File) SetCellStyle(sheet, hcell, vcell string, styleID int) error {
 
 	xlsx := f.workSheetReader(sheet)
 	prepareSheetXML(xlsx, vcol, vrow)
+	makeContiguousColumns(xlsx, hrow, vrow, vcol)
 
 	for r := hrowIdx; r <= vrowIdx; r++ {
 		for k := hcolIdx; k <= vcolIdx; k++ {


### PR DESCRIPTION
# PR Details

## Description

We don't need to backfill columns into every row for most purposes
Provided makeContiguousColumns for setting styles where we do
need it for a specific region.

Added a benchmark to monitor progress. For 50,000 rows this went
from about 11 seconds to 1 second. The improvements are more
dramatic as the row/column count increases.

## Related Issue

#382 

## Motivation and Context

This allows writing much larger files, quickly.

## How Has This Been Tested

This should be transparent but I made sure all the tests pass, added a benchmark, and
created some files to make sure they saved correctly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
