### PR TITLE
Fix 439

### DIFF
--- a/rows_test.go
+++ b/rows_test.go
@@ -39,9 +39,6 @@ func TestRows(t *testing.T) {
 	if !assert.Equal(t, collectedRows, returnedRows) {
 		t.FailNow()
 	}
-
-	r := Rows{}
-	r.Columns()
 }
 
 func TestRowsError(t *testing.T) {
@@ -668,6 +665,21 @@ func TestDuplicateRowInvalidRownum(t *testing.T) {
 				}
 				assert.NoError(t, xlsx.SaveAs(fmt.Sprintf(outFile, name)))
 			})
+		}
+	}
+}
+
+func BenchmarkRows(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f, _ := OpenFile(filepath.Join("test", "Book1.xlsx"))
+		rows, _ := f.Rows("Sheet2")
+		for rows.Next() {
+			row, _ := rows.Columns()
+			for i := range row {
+				if i >= 0 {
+					continue
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Description

We were parsing the entire sheet twice which was leading to extra memory consumption and parsing time when reading an excel sheet with `Rows()` and `GetRows()`

## Related Issue

#439 

## Motivation and Context

This effectively halves the read time for spreadsheets.

## How Has This Been Tested

All tests continue to pass, and I added a benchmark to validate the performance improvement.
Before:
BenchmarkRows-8   	     500	   2434130 ns/op	  888380 B/op	    8612 allocs/op
OnlyOnce:
BenchmarkRows-8   	    1000	   2123277 ns/op	  811150 B/op	    7173 allocs/op

When run against the data sheet used in #439 the read time went from ~6.4 seconds on my machine to ~3.8 seconds.

## Important!

The one thing I did change is that if you declare a blank Rows struct and immediately call Columns on it you will get an index out of bounds error since you'll be trying to access nothing. However, this didn't seem realistic since users should be getting the rows struct by calling `file.Rows("someSheet")` and it works correctly under those conditions. I deleted the part of the test that looked for this behavior. I can add a bounds check to `Columns()` if you prefer but it seems unnecessary to me.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
