### PR TITLE
Further improve read performance

### DIFF
--- a/excelize_test.go
+++ b/excelize_test.go
@@ -1003,7 +1003,11 @@ func TestSharedStrings(t *testing.T) {
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	f.GetRows("Sheet1")
+	rows, err := f.GetRows("Sheet1")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	assert.Equal(t, "A", rows[0][0])
 }
 
 func TestSetSheetRow(t *testing.T) {

--- a/rows.go
+++ b/rows.go
@@ -112,8 +112,8 @@ func (f *File) Rows(sheet string) (*Rows, error) {
 		return nil, ErrSheetNotExist{sheet}
 	}
 	if xlsx != nil {
-		output, _ := xml.Marshal(f.Sheet[name])
-		f.saveFileList(name, replaceWorkSheetsRelationshipsNameSpaceBytes(output))
+		data := f.readXML(name)
+		f.saveFileList(name, replaceWorkSheetsRelationshipsNameSpaceBytes(namespaceStrictToTransitional(data)))
 	}
 	return &Rows{
 		f:    f,


### PR DESCRIPTION
## Description

Instead of re-encoding the full sheet to change the namespaces
in the encoded bytes, read the sheet again and do the byte
replacements there.

In this case, file access ends up being more performant than
marshaling the sheet back to XML.

In the `SharedStrings` test, ensure the strings are actually read.

I actually think this entire operation is unnecessary since we shouldn't be modifying anything on a read but doing the change this way ensures my PR is fully passive in case anyone was relying on the behavior.

## Related Issue

 #439

## Motivation and Context

This further improves the read performance.

Before
BenchmarkRows-8   	    1000	   2177328 ns/op	  811432 B/op	    7173 allocs/op
After
BenchmarkRows-8   	    1000	   2035770 ns/op	  768284 B/op	    6883 allocs/op

On the test file I was using before this reduced the read time from ~3.8 seconds to ~2.5 seconds.

## How Has This Been Tested

I ran (and updated) all the unit tests and ran it against the same test files as before.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
