### PR TITLE
Get sheet names based on index

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -317,14 +317,11 @@ func (f *File) SetSheetName(oldName, newName string) {
 // string.
 func (f *File) GetSheetName(index int) string {
 	wb := f.workbookReader()
-	if wb != nil {
-		for _, sheet := range wb.Sheets.Sheet {
-			if sheet.SheetID == index {
-				return sheet.Name
-			}
-		}
+	realIdx := index - 1 // sheets are 1 based index, but we're checking against an array
+	if wb == nil || realIdx < 0 || realIdx >= len(wb.Sheets.Sheet) {
+		return ""
 	}
-	return ""
+	return wb.Sheets.Sheet[realIdx].Name
 }
 
 // GetSheetIndex provides a function to get worksheet index of XLSX by given
@@ -357,8 +354,8 @@ func (f *File) GetSheetMap() map[int]string {
 	wb := f.workbookReader()
 	sheetMap := map[int]string{}
 	if wb != nil {
-		for _, sheet := range wb.Sheets.Sheet {
-			sheetMap[sheet.SheetID] = sheet.Name
+		for i, sheet := range wb.Sheets.Sheet {
+			sheetMap[i+1] = sheet.Name
 		}
 	}
 	return sheetMap

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -225,3 +225,24 @@ func TestUngroupSheets(t *testing.T) {
 	}
 	assert.NoError(t, f.UngroupSheets())
 }
+
+func TestGetSheetName(t *testing.T) {
+	f, _ := excelize.OpenFile(filepath.Join("test", "Book1.xlsx"))
+	assert.Equal(t, "Sheet1", f.GetSheetName(1))
+	assert.Equal(t, "Sheet2", f.GetSheetName(2))
+	assert.Equal(t, "", f.GetSheetName(0))
+	assert.Equal(t, "", f.GetSheetName(3))
+}
+
+func TestGetSheetMap(t *testing.T) {
+	expectedMap := map[int]string{
+		1: "Sheet1",
+		2: "Sheet2",
+	}
+	f, _ := excelize.OpenFile(filepath.Join("test", "Book1.xlsx"))
+	sheetMap := f.GetSheetMap()
+	for idx, name := range sheetMap {
+		assert.Equal(t, expectedMap[idx], name)
+	}
+	assert.Equal(t, len(sheetMap), 2)
+}


### PR DESCRIPTION
## Description

SheetID only seems to indicate the file name for the sheet.
Check the sheets list based on index instead. Reordering sheets in Excel changes the order they appear in that list.

## Related Issue

Fixes #457

## Motivation and Context

Using SheetID is not a reliable way to get a sheet's name based on index.

## How Has This Been Tested

Verified with the test file given in #457, and against the existing files in the test directory of this project. I added unit tests to ensure the expected matches.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
