### PR TITLE
SetCellValue: use fmt.Sprint(v) instead of fmt.Sprintf("%v", v)

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -94,7 +94,7 @@ func (f *File) SetCellValue(sheet, axis string, value interface{}) error {
 	case nil:
 		err = f.SetCellStr(sheet, axis, "")
 	default:
-		err = f.SetCellStr(sheet, axis, fmt.Sprintf("%v", value))
+		err = f.SetCellStr(sheet, axis, fmt.Sprint(value))
 	}
 	return err
 }


### PR DESCRIPTION
## Description

In method `SetCellValue`, use `fmt.Sprint(v)` instead of `fmt.Sprintf("%v", v)`.

## Motivation and Context

Because `fmt.Sprint(v)` does the same thing as `fmt.Sprintf("%v", v)`, but without having to parse a format string. So this is more efficient.

## How Has This Been Tested

    GO111MODULE=on go test github.com/360EntSecGroup-Skylar/excelize/v2/...

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
