### PR TITLE
add missing error check in SetSheetRow()

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -471,12 +471,14 @@ func (f *File) SetSheetRow(sheet, axis string, slice interface{}) error {
 
 	for i := 0; i < v.Len(); i++ {
 		cell, err := CoordinatesToCellName(col+i, row)
-		// Error should never happens here. But keep ckecking to early detect regresions
-		// if it will be introduced in furure
+		// Error should never happens here. But keep checking to early detect regresions
+		// if it will be introduced in future.
 		if err != nil {
 			return err
 		}
-		f.SetCellValue(sheet, cell, v.Index(i).Interface())
+		if err := f.SetCellValue(sheet, cell, v.Index(i).Interface()); err != nil {
+			return err
+		}
 	}
 	return err
 }


### PR DESCRIPTION
# PR Details

add missing error check in SetSheetRow() when call SetCellValue().

## Description

Fix typos in comments;
Check return error when call SetCellValue().

## Related Issue

None.

## Motivation and Context

When set  cell value of type time.Time with timezone other than UTC,  the result is empty string.
After go through excelize code, I found the bug.

## How Has This Been Tested

No existing suitable tests to add this case, and this fix is pretty straight forward.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
