### PR TITLE
Updating Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Supports saving a file without losing original charts of XLSX. This library need
 ### Installation
 
 ```bash
-go get github.com/360EntSecGroup-Skylar/excelize/v2
+go get github.com/360EntSecGroup-Skylar/excelize
 ```
 
 ### Create XLSX file
@@ -34,7 +34,7 @@ package main
 import (
     "fmt"
 
-    "github.com/360EntSecGroup-Skylar/excelize/v2"
+    "github.com/360EntSecGroup-Skylar/excelize"
 )
 
 func main() {
@@ -64,7 +64,7 @@ package main
 import (
     "fmt"
 
-    "github.com/360EntSecGroup-Skylar/excelize/v2"
+    "github.com/360EntSecGroup-Skylar/excelize"
 )
 
 func main() {
@@ -103,7 +103,7 @@ package main
 import (
     "fmt"
 
-    "github.com/360EntSecGroup-Skylar/excelize/v2"
+    "github.com/360EntSecGroup-Skylar/excelize"
 )
 
 func main() {
@@ -140,7 +140,7 @@ import (
     _ "image/jpeg"
     _ "image/png"
 
-    "github.com/360EntSecGroup-Skylar/excelize/v2"
+    "github.com/360EntSecGroup-Skylar/excelize"
 )
 
 func main() {


### PR DESCRIPTION
Removing the /v2 on the package url as it does not work with the ```go get``` command.

# PR Details

The go get command fails with the /v2 at the end of the package url.  Removing /v2 works and the package is installed.

## Description

The go get command fails with the /v2 at the end of the package url.  Removing /v2 works and the package is installed.

## Related Issue

No related issue.

## Motivation and Context

The go get command fails with the /v2 at the end of the package url.  Removing /v2 works and the package is installed.

## How Has This Been Tested

This has not been tested as it is a documentation change.

## Types of changes

- [X ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X ] My code follows the code style of this project.
- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
