### PR TITLE
Allow access to more formula attributes in SetCellFormula

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -273,9 +273,15 @@ func (f *File) GetCellFormula(sheet, axis string) (string, error) {
 	})
 }
 
+// FormulaOpts can be passed to SetCellFormula to use other formula types.
+type FormulaOpts struct {
+	Type *string // Formula type
+	Ref  *string // Shared formula ref
+}
+
 // SetCellFormula provides a function to set cell formula by given string and
 // worksheet name.
-func (f *File) SetCellFormula(sheet, axis, formula string) error {
+func (f *File) SetCellFormula(sheet, axis, formula string, opts ...FormulaOpts) error {
 	xlsx, err := f.workSheetReader(sheet)
 	if err != nil {
 		return err
@@ -295,6 +301,17 @@ func (f *File) SetCellFormula(sheet, axis, formula string) error {
 	} else {
 		cellData.F = &xlsxF{Content: formula}
 	}
+
+	for _, o := range opts {
+		if o.Type != nil {
+			cellData.F.T = *o.Type
+		}
+
+		if o.Ref != nil {
+			cellData.F.Ref = *o.Ref
+		}
+	}
+
 	return err
 }
 


### PR DESCRIPTION
# PR Details

## Description

Make SetCellFormula variadic to not break API.
The new arguments are option arguments in which the type of
the formula and the ref attribute may be set.
These need to be set for an array formula to work.

## Motivation and Context

I needed to create a document with an array formula.

## How Has This Been Tested

I created a document with formulas like this: `=ROUND(STDEVP(IF($U$28:$U$51=$A$13,$J$28:$J$51)),0)`
They are interpreted correctly by LibreOffice 6.0 and by online Office 365.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [?] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [TLDR] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
