### PR TITLE
fix sheepID not be related with sheet array's index

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -85,6 +85,10 @@ func (f *File) workbookReader() *xlsxWorkbook {
 		var content xlsxWorkbook
 		_ = xml.Unmarshal(namespaceStrictToTransitional(f.readXML("xl/workbook.xml")), &content)
 		f.WorkBook = &content
+		//rebuild sheetID
+		for i, _ := range f.WorkBook.Sheets.Sheet {
+			f.WorkBook.Sheets.Sheet[i].SheetID = i + 1
+		}
 	}
 	return f.WorkBook
 }


### PR DESCRIPTION
# PR Details
Make the sheepID to be related with sheet array's index

## Description
When some excel sheep's sheepID maybe any number instead of start 1. for example I have a xslx file only one sheet, I GetSheetIndex('firstsheet') is 15,  then I call GetSheetName(15) cannot get any sheet name just a empty string return.

## Related Issue
 #485 

## Motivation and Context

even if the sheetID not start 1, GetSheetName can get the correct name.

## How Has This Been Tested

My excel sheet copy operator can correct call, and the result is what I expect.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

