### PR TITLE
solve ending space missing

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -229,7 +229,7 @@ func (f *File) SetCellStr(sheet, axis, value string) error {
 		value = value[0:32767]
 	}
 	// Leading space(s) character detection.
-	if len(value) > 0 && value[0] == 32 {
+	if len(value) > 0 && (value[0] == 32 || value[len(value)-1] == 32) {
 		cellData.XMLSpace = xml.Attr{
 			Name:  xml.Name{Space: NameSpaceXML, Local: "space"},
 			Value: "preserve",


### PR DESCRIPTION
# Solve ending space missing

<!--- Provide a general summary of your changes in the Title above -->

## if the last is space , set xml attribute，xml:space="preserve"

<!--- Describe your changes in detail -->

## If I open the workbook with excel, ending space are missing

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## If I open the workbook with excel, ending space are missing

<!--- Why is this change required? What problem does it solve? -->

## Create excel , open the workbook with excel, ending space are existedCreate excel .

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
