### PR TITLE
fix rows next

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -57,7 +57,8 @@ type Rows struct {
 
 // Next will return true if find the next row element.
 func (rows *Rows) Next() bool {
-	return rows.curRow < len(rows.rows)
+	rows.curRow++
+	return rows.curRow <= len(rows.rows)
 }
 
 // Error will return the error when the find next row element
@@ -67,8 +68,7 @@ func (rows *Rows) Error() error {
 
 // Columns return the current row's column values
 func (rows *Rows) Columns() ([]string, error) {
-	curRow := rows.rows[rows.curRow]
-	rows.curRow++
+	curRow := rows.rows[rows.curRow-1]
 
 	columns := make([]string, len(curRow.C))
 	d := rows.f.sharedStringsReader()

--- a/rows_test.go
+++ b/rows_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRows(t *testing.T) {
@@ -39,6 +40,25 @@ func TestRows(t *testing.T) {
 	if !assert.Equal(t, collectedRows, returnedRows) {
 		t.FailNow()
 	}
+}
+
+// test bug https://github.com/360EntSecGroup-Skylar/excelize/issues/502
+func TestRowsIterator(t *testing.T) {
+	const (
+		sheet2         = "Sheet2"
+		expectedNumRow = 11
+	)
+	xlsx, err := OpenFile(filepath.Join("test", "Book1.xlsx"))
+	require.NoError(t, err)
+
+	rows, err := xlsx.Rows(sheet2)
+	require.NoError(t, err)
+	var rowCount int
+	for rows.Next() {
+		rowCount++
+		require.True(t, rowCount <= expectedNumRow, "rowCount is greater than expected")
+	}
+	assert.Equal(t, expectedNumRow, rowCount)
 }
 
 func TestRowsError(t *testing.T) {


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
 Fix bug
## Description
rows.Next should increase the `curRow` variable
while `rows.Columns` shouldn't do it
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/360EntSecGroup-Skylar/excelize/issues/502
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
- Add a unit test. Using require to cancel the test immediately instead of 
```
if !assert.NoError(t, rows.Error()) {
	t.FailNow()
}
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
