### PR TITLE
Pre-allocate some memory when reading files

### DIFF
--- a/excelize_test.go
+++ b/excelize_test.go
@@ -1278,3 +1278,9 @@ func fillCells(f *File, sheet string, colCount, rowCount int) {
 		}
 	}
 }
+
+func BenchmarkOpenFile(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		OpenFile(filepath.Join("test", "Book1.xlsx"))
+	}
+}

--- a/lib.go
+++ b/lib.go
@@ -22,14 +22,12 @@ import (
 // ReadZipReader can be used to read an XLSX in memory without touching the
 // filesystem.
 func ReadZipReader(r *zip.Reader) (map[string][]byte, int, error) {
-	fileList := make(map[string][]byte)
+	fileList := make(map[string][]byte, len(r.File))
 	worksheets := 0
 	for _, v := range r.File {
 		fileList[v.Name] = readFile(v)
-		if len(v.Name) > 18 {
-			if v.Name[0:19] == "xl/worksheets/sheet" {
-				worksheets++
-			}
+		if strings.HasPrefix(v.Name, "xl/worksheets/sheet") {
+			worksheets++
 		}
 	}
 	return fileList, worksheets, nil
@@ -58,7 +56,8 @@ func readFile(file *zip.File) []byte {
 	if err != nil {
 		log.Fatal(err)
 	}
-	buff := bytes.NewBuffer(nil)
+	dat := make([]byte, 0, file.FileInfo().Size())
+	buff := bytes.NewBuffer(dat)
 	_, _ = io.Copy(buff, rc)
 	rc.Close()
 	return buff.Bytes()

--- a/rows_test.go
+++ b/rows_test.go
@@ -695,8 +695,8 @@ func TestErrSheetNotExistError(t *testing.T) {
 }
 
 func BenchmarkRows(b *testing.B) {
+	f, _ := OpenFile(filepath.Join("test", "Book1.xlsx"))
 	for i := 0; i < b.N; i++ {
-		f, _ := OpenFile(filepath.Join("test", "Book1.xlsx"))
 		rows, _ := f.Rows("Sheet2")
 		for rows.Next() {
 			row, _ := rows.Columns()


### PR DESCRIPTION
# PR Details

This makes it so we pre-allocate some of the memory we need when reading files.

## Description

We know how many files will be stored, and how big they will be so we can use those to allocate buffers instead of growing them with append.

I also changed the Rows benchmark to not include file opening as part of it, and gave opening a file its own benchmark. No massive improvements here, just a small reduction in memory pressure when reading.

Old
BenchmarkOpenFile-8   	    1000	   1585980 ns/op	  631000 B/op	    4533 allocs/op
New
BenchmarkOpenFile-8   	    1000	   1521844 ns/op	  547654 B/op	    4498 allocs/op

## Related Issue

I could open an issue for it, but this wasn't causing any problems worth raising an issue for.

## Motivation and Context

Just reducing memory pressure a little when reading a lot of files.

## How Has This Been Tested

Unit tests still pass, still able to read a test file.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
