### PR TITLE
Reduce allocations when writing

### DIFF
--- a/excelize.go
+++ b/excelize.go
@@ -155,20 +155,12 @@ func checkSheet(xlsx *xlsxWorksheet) {
 			row = lastRow
 		}
 	}
-	sheetData := xlsxSheetData{}
-	existsRows := map[int]int{}
-	for k := range xlsx.SheetData.Row {
-		existsRows[xlsx.SheetData.Row[k].R] = k
+	sheetData := xlsxSheetData{Row: make([]xlsxRow, row)}
+	for _, r := range xlsx.SheetData.Row {
+		sheetData.Row[r.R-1] = r
 	}
-	for i := 0; i < row; i++ {
-		_, ok := existsRows[i+1]
-		if ok {
-			sheetData.Row = append(sheetData.Row, xlsx.SheetData.Row[existsRows[i+1]])
-		} else {
-			sheetData.Row = append(sheetData.Row, xlsxRow{
-				R: i + 1,
-			})
-		}
+	for i := 1; i <= row; i++ {
+		sheetData.Row[i-1].R = i
 	}
 	xlsx.SheetData = sheetData
 }

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,27 @@
+package excelize
+
+import (
+	"testing"
+)
+
+func BenchmarkWrite(b *testing.B) {
+	const s = "This is test data"
+	for i := 0; i < b.N; i++ {
+		f := NewFile()
+		for row := 1; row <= 10000; row++ {
+			for col := 1; col <= 20; col++ {
+				val, err := CoordinatesToCellName(col, row)
+				if err != nil {
+					panic(err)
+				}
+				f.SetCellDefault("Sheet1", val, s)
+			}
+		}
+		// Save xlsx file by the given path.
+		err := f.SaveAs("./test.xlsx")
+		if err != nil {
+			panic(err)
+		}
+	}
+
+}

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -430,6 +430,10 @@ type xlsxC struct {
 	XMLSpace xml.Attr `xml:"space,attr,omitempty"`
 }
 
+func (c *xlsxC) hasValue() bool {
+	return c.S != 0 || c.V != "" || c.F != nil || c.T != ""
+}
+
 // xlsxF directly maps the f element in the namespace
 // http://schemas.openxmlformats.org/spreadsheetml/2006/main - currently I have
 // not checked it for completeness - it does as much as I need.


### PR DESCRIPTION
# PR Details

Fix #494

If a row is full, don't bother allocating a new one, just return it.

Use the last populated row as a hint for the size of new rows.

Simplify checkSheet to remove row map (tiny performance improvement, mostly just easier to follow now)

## Related Issue

#494 

## Motivation and Context

Reduce memory consumed while creating a document

## How Has This Been Tested

Added a new benchmark, ensured tests continue to pass

Master
BenchmarkWrite-8   	       2	 601920270 ns/op	207277296 B/op	 1893770 allocs/op

This fix
BenchmarkWrite-8   	       2	 567284257 ns/op	127115028 B/op	 1833744 allocs/op

Rows:
Master
BenchmarkRows-8   	   10000	    362571 ns/op	 2010561 B/op	      30 allocs/op
This fix
BenchmarkRows-8   	   10000	    349607 ns/op	 2010560 B/op	      30 allocs/op

Performance wise, the change I made to rows barely makes a difference, most of that was likely stack allocated anyway. This is just simpler.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
