### PR TITLE
Fix default font color in chart is too bright issue

### DIFF
--- a/chart.go
+++ b/chart.go
@@ -1842,7 +1842,7 @@ func (f *File) drawPlotAreaTxPr() *cTxPr {
 					Baseline: 0,
 					SolidFill: &aSolidFill{
 						SchemeClr: &aSchemeClr{
-							Val:    "tx1",
+							Val:    "t1",
 							LumMod: &attrValInt{Val: intPtr(15000)},
 							LumOff: &attrValInt{Val: intPtr(85000)},
 						},


### PR DESCRIPTION
# PR Details
Fix default font color in chart is too bright issue

<!--- Provide a general summary of your changes in the Title above -->

## Description
Change drawPlotAreaTxPr() font type "tx1" to "t1" according to [Microsoft openxml document](https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.colorschememapping.text1?view=openxml-2.8.1)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
