### PR TITLE
Add a function to hide all columns starting from one

### DIFF
--- a/col_test.go
+++ b/col_test.go
@@ -18,11 +18,20 @@ func TestColumnVisibility(t *testing.T) {
 		assert.Equal(t, true, visible)
 		assert.NoError(t, err)
 
-		// Test get column visiable on not exists worksheet.
+		assert.NoError(t, f.SetColsVisibleFrom("Sheet1", "F", false))
+		assert.NoError(t, f.SetColsVisibleFrom("Sheet1", "F", true))
+		visible, err := f.GetColVisible("Sheet1", "F")
+		assert.Equal(t, true, visible)
+		assert.NoError(t, err)
+		visible, err = f.GetColVisible("Sheet1", "G")
+		assert.Equal(t, true, visible)
+		assert.NoError(t, err)
+
+		// Test get column visible on not exists worksheet.
 		_, err = f.GetColVisible("SheetN", "F")
 		assert.EqualError(t, err, "sheet SheetN is not exist")
 
-		// Test get column visiable with illegal cell coordinates.
+		// Test get column visible with illegal cell coordinates.
 		_, err = f.GetColVisible("Sheet1", "*")
 		assert.EqualError(t, err, `invalid column name "*"`)
 		assert.EqualError(t, f.SetColVisible("Sheet1", "*", false), `invalid column name "*"`)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/360EntSecGroup-Skylar/excelize/v2
+module github.com/Amodio/excelize/v2
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Amodio/excelize/v2
+module github.com/360EntSecGroup-Skylar/excelize/v2
 
 go 1.12
 


### PR DESCRIPTION
# PR Details

We need a function to hide both rows or columns from one, this PR deals only with columns.

## Description

Fixed some typos. Creation of SetColsVisibleFrom(), which is tested.

## Related Issue

#559 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)