### PR TITLE
Reduce redundant memory copy in getRowHeight

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -238,7 +238,8 @@ func (f *File) SetRowHeight(sheet string, row int, height float64) error {
 // name and row index.
 func (f *File) getRowHeight(sheet string, row int) int {
 	xlsx, _ := f.workSheetReader(sheet)
-	for _, v := range xlsx.SheetData.Row {
+	for i := range xlsx.SheetData.Row {
+		v := &xlsx.SheetData.Row[i]
 		if v.R == row+1 && v.Ht != 0 {
 			return int(convertRowHeightToPixels(v.Ht))
 		}


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

https://github.com/360EntSecGroup-Skylar/excelize/blob/821a5d86725eb80b3f9e806d91eca5859497c2fa/rows.go#L241
v is copy by value, which cause a lot call to runtime.duffcopy, lead to slow performance.
Will this patch, generate a workbook with 8320 AddPicture calls take only 29s instead of 127s.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
