### PR TITLE
Exported function to convert excel date to time

### DIFF
--- a/date.go
+++ b/date.go
@@ -172,3 +172,11 @@ func timeFromExcelTime(excelTime float64, date1904 bool) time.Time {
 	durationPart := time.Duration(dayNanoSeconds * floatPart)
 	return date.Add(durationDays).Add(durationPart)
 }
+
+// ExcelDateToTime converts a float-based excel date representation to a time.Time.
+func ExcelDateToTime(excelDate float64, use1904Format bool) (time.Time, error) {
+	if excelDate < 0 {
+		return time.Time{}, newInvalidExcelDateError(excelDate)
+	}
+	return timeFromExcelTime(excelDate, use1904Format), nil
+}

--- a/date_test.go
+++ b/date_test.go
@@ -28,6 +28,14 @@ var trueExpectedDateList = []dateTest{
 	{401769.00000000000, time.Date(3000, time.January, 1, 0, 0, 0, 0, time.UTC)},
 }
 
+var excelTimeInputList = []dateTest{
+	{0.0, time.Date(1899, 12, 30, 0, 0, 0, 0, time.UTC)},
+	{60.0, time.Date(1900, 2, 28, 0, 0, 0, 0, time.UTC)},
+	{61.0, time.Date(1900, 3, 1, 0, 0, 0, 0, time.UTC)},
+	{41275.0, time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC)},
+	{401769.0, time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC)},
+}
+
 func TestTimeToExcelTime(t *testing.T) {
 	for i, test := range trueExpectedDateList {
 		t.Run(fmt.Sprintf("TestData%d", i+1), func(t *testing.T) {
@@ -53,15 +61,7 @@ func TestTimeToExcelTime_Timezone(t *testing.T) {
 }
 
 func TestTimeFromExcelTime(t *testing.T) {
-	trueExpectedInputList := []dateTest{
-		{0.0, time.Date(1899, 12, 30, 0, 0, 0, 0, time.UTC)},
-		{60.0, time.Date(1900, 2, 28, 0, 0, 0, 0, time.UTC)},
-		{61.0, time.Date(1900, 3, 1, 0, 0, 0, 0, time.UTC)},
-		{41275.0, time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC)},
-		{401769.0, time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC)},
-	}
-
-	for i, test := range trueExpectedInputList {
+	for i, test := range excelTimeInputList {
 		t.Run(fmt.Sprintf("TestData%d", i+1), func(t *testing.T) {
 			assert.Equal(t, test.GoValue, timeFromExcelTime(test.ExcelValue, false))
 		})
@@ -72,4 +72,18 @@ func TestTimeFromExcelTime_1904(t *testing.T) {
 	_, _ = shiftJulianToNoon(1, -0.6)
 	timeFromExcelTime(61, true)
 	timeFromExcelTime(62, true)
+}
+
+func TestExcelDateToTime(t *testing.T) {
+	// Check normal case
+	for i, test := range excelTimeInputList {
+		t.Run(fmt.Sprintf("TestData%d", i+1), func(t *testing.T) {
+			timeValue, err := ExcelDateToTime(test.ExcelValue, false)
+			assert.Equal(t, test.GoValue, timeValue)
+			assert.NoError(t, err)
+		})
+	}
+	// Check error case
+	_, err := ExcelDateToTime(-1, false)
+	assert.EqualError(t, err, "invalid date value -1.000000, negative values are not supported supported")
 }

--- a/errors.go
+++ b/errors.go
@@ -22,3 +22,7 @@ func newInvalidRowNumberError(row int) error {
 func newInvalidCellNameError(cell string) error {
 	return fmt.Errorf("invalid cell name %q", cell)
 }
+
+func newInvalidExcelDateError(dateValue float64) error {
+	return fmt.Errorf("invalid date value %f, negative values are not supported supported", dateValue)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -19,3 +19,7 @@ func TestNewInvalidCellNameError(t *testing.T) {
 	assert.EqualError(t, newInvalidCellNameError("A"), "invalid cell name \"A\"")
 	assert.EqualError(t, newInvalidCellNameError(""), "invalid cell name \"\"")
 }
+
+func TestNewInvalidExcelDateError(t *testing.T) {
+	assert.EqualError(t, newInvalidExcelDateError(-1), "invalid date value -1.000000, negative values are not supported supported")
+}


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This change exports a function `ExcelDateToTime` to convert a float-represented excel date to a golang `time.Time`.

## Related Issue

Resolves 360EntSecGroup-Skylar/excelize#140

## Motivation and Context

While processing dates in excel files, often specific date formats are needed that may not be supported, as seen in the discussion under issues #177 and #283 . Alternatively a workaround is to read the date in a supported format and then convert it again, but that can be clunky in my opinion. Having a `time.Time` representation on the other hand provides much more flexibility in dealing with dates.

## How Has This Been Tested

The function is a wrapper around an existing un-exported function, with an additional check for invalid input. A test has been added for testing the error case.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
