### PR TITLE
Replace bytes.NewReader(stringToBytes(s)) with strings.NewReader(s)

### DIFF
--- a/drawing.go
+++ b/drawing.go
@@ -1288,7 +1288,7 @@ func (f *File) deleteDrawing(col, row int, drawingXML, drawingType string) (err 
 	}
 	for idx := 0; idx < len(wsDr.TwoCellAnchor); idx++ {
 		deTwoCellAnchor = new(decodeTwoCellAnchor)
-		if err = f.xmlNewDecoder(bytes.NewReader(stringToBytes("<decodeTwoCellAnchor>" + wsDr.TwoCellAnchor[idx].GraphicFrame + "</decodeTwoCellAnchor>"))).
+		if err = f.xmlNewDecoder(strings.NewReader("<decodeTwoCellAnchor>" + wsDr.TwoCellAnchor[idx].GraphicFrame + "</decodeTwoCellAnchor>")).
 			Decode(deTwoCellAnchor); err != nil && err != io.EOF {
 			err = fmt.Errorf("xml decode error: %s", err)
 			return

--- a/picture.go
+++ b/picture.go
@@ -512,7 +512,7 @@ func (f *File) getPicture(row, col int, drawingXML, drawingRelationships string)
 	err = nil
 	for _, anchor := range deWsDr.TwoCellAnchor {
 		deTwoCellAnchor = new(decodeTwoCellAnchor)
-		if err = f.xmlNewDecoder(bytes.NewReader(stringToBytes("<decodeTwoCellAnchor>" + anchor.Content + "</decodeTwoCellAnchor>"))).
+		if err = f.xmlNewDecoder(strings.NewReader("<decodeTwoCellAnchor>" + anchor.Content + "</decodeTwoCellAnchor>")).
 			Decode(deTwoCellAnchor); err != nil && err != io.EOF {
 			err = fmt.Errorf("xml decode error: %s", err)
 			return

--- a/sparkline.go
+++ b/sparkline.go
@@ -10,7 +10,6 @@
 package excelize
 
 import (
-	"bytes"
 	"encoding/xml"
 	"errors"
 	"io"
@@ -509,14 +508,14 @@ func (f *File) appendSparkline(ws *xlsxWorksheet, group *xlsxX14SparklineGroup, 
 		sparklineGroupsBytes, sparklineGroupBytes, extLstBytes []byte
 	)
 	decodeExtLst = new(decodeWorksheetExt)
-	if err = f.xmlNewDecoder(bytes.NewReader([]byte("<extLst>" + ws.ExtLst.Ext + "</extLst>"))).
+	if err = f.xmlNewDecoder(strings.NewReader("<extLst>" + ws.ExtLst.Ext + "</extLst>")).
 		Decode(decodeExtLst); err != nil && err != io.EOF {
 		return
 	}
 	for idx, ext = range decodeExtLst.Ext {
 		if ext.URI == ExtURISparklineGroups {
 			decodeSparklineGroups = new(decodeX14SparklineGroups)
-			if err = f.xmlNewDecoder(bytes.NewReader(stringToBytes(ext.Content))).
+			if err = f.xmlNewDecoder(strings.NewReader(ext.Content)).
 				Decode(decodeSparklineGroups); err != nil && err != io.EOF {
 				return
 			}


### PR DESCRIPTION
## Description

Drop unnecessary uses of internal function `stringToBytes`. 

## Motivation and Context

`stringToBytes` uses package `unsafe`. `stringToBytes` is just a speed hack that kills portability. `stringToBytes` doesn't have a benchmark ensuring it helps for spped

This also reduces allocations as shown by benchmarks results.

## How Has This Been Tested

```
go test
go test -bench B  -benchmem   # BenchmarkSetCellValue still fails like before my change
```

Benchmark before (66d0272f6af59b5f0c97a304379a795420a43e8b):
```
goos: darwin
goarch: amd64
pkg: github.com/360EntSecGroup-Skylar/excelize/v2
BenchmarkOpenFile-4              	     566	   2753542 ns/op	  534112 B/op	    4476 allocs/op
BenchmarkWrite-4                 	       2	 630348442 ns/op	122600148 B/op	 1833689 allocs/op
BenchmarkAddPictureFromBytes-4   	   10000	    583967 ns/op	    6939 B/op	      38 allocs/op
BenchmarkRows-4                  	    2625	    477113 ns/op	  103223 B/op	    2304 allocs/op
BenchmarkStreamWriter-4          	    1809	    565083 ns/op	  133545 B/op	    4464 allocs/op
```

Benchmark after:
```
goos: darwin
goarch: amd64
pkg: github.com/360EntSecGroup-Skylar/excelize/v2
BenchmarkOpenFile-4              	     631	   1977463 ns/op	  533661 B/op	    4475 allocs/op
BenchmarkWrite-4                 	       2	 628304756 ns/op	122599896 B/op	 1833686 allocs/op
BenchmarkAddPictureFromBytes-4   	   10000	    562723 ns/op	    6939 B/op	      38 allocs/op
BenchmarkRows-4                  	    2395	    442256 ns/op	  103245 B/op	    2305 allocs/op
BenchmarkStreamWriter-4          	    1896	    731839 ns/op	  133538 B/op	    4463 allocs/op
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
