### PR TITLE
Add set rows visibility method

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -26,3 +26,7 @@ func newInvalidCellNameError(cell string) error {
 func newInvalidExcelDateError(dateValue float64) error {
 	return fmt.Errorf("invalid date value %f, negative values are not supported supported", dateValue)
 }
+
+func newInvalidRowNumbersError() error {
+	return fmt.Errorf("invalid rows value, no rows to process")
+}

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/rows.go
+++ b/rows.go
@@ -321,6 +321,27 @@ func (xlsx *xlsxC) getValueFrom(f *File, d *xlsxSST) (string, error) {
 	}
 }
 
+// SetRowsVisibility provides a function to set visibility to multiple rows
+// by given worksheet name and Excel row numbers. For example, hide rows
+// 2, 3 and 4 in Sheet1:
+//
+//    err := f.SetRowsVisibility("Sheet1", false, 2, 3, 4)
+//
+func (f *File) SetRowsVisibility(sheet string, visible bool, rows ...int) error {
+	if len(rows) == 0 {
+		return newInvalidRowNumbersError()
+	}
+
+	for _, row := range rows {
+		err := f.SetRowVisible(sheet, row, visible)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // SetRowVisible provides a function to set visible of a single row by given
 // worksheet name and Excel row number. For example, hide row 2 in Sheet1:
 //

--- a/rows_test.go
+++ b/rows_test.go
@@ -188,6 +188,26 @@ func TestRowVisibility(t *testing.T) {
 	assert.EqualError(t, f.SetRowVisible("Sheet3", 0, true), "invalid row number 0")
 	assert.EqualError(t, f.SetRowVisible("SheetN", 2, false), "sheet SheetN is not exist")
 
+	assert.Error(t, f.SetRowsVisibility("Sheet3", true))
+
+	err = f.SetRowsVisibility("Sheet3", true, 3, 4)
+	assert.NoError(t, err)
+	visiable, err = f.GetRowVisible("Sheet3", 3)
+	assert.NoError(t, err)
+	assert.Equal(t, true, visiable)
+	visiable, err = f.GetRowVisible("Sheet3", 4)
+	assert.NoError(t, err)
+	assert.Equal(t, true, visiable)
+
+	err = f.SetRowsVisibility("Sheet3", false, 3, 4)
+	assert.NoError(t, err)
+	visiable, err = f.GetRowVisible("Sheet3", 3)
+	assert.NoError(t, err)
+	assert.Equal(t, false, visiable)
+	visiable, err = f.GetRowVisible("Sheet3", 4)
+	assert.NoError(t, err)
+	assert.Equal(t, false, visiable)
+
 	visible, err := f.GetRowVisible("Sheet3", 0)
 	assert.Equal(t, false, visible)
 	assert.EqualError(t, err, "invalid row number 0")


### PR DESCRIPTION
# PR Details

## Description

This should create a method that allows the developer to apply visibility to multiple rows.

## Related Issue

Resolves #626 

## Motivation and Context

This could work as an enhancement to allow the developer to use a single statement to apply the visibility to multiple rows.

## How Has This Been Tested

I've added test cases to cover the new method with its possible error.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
