### PR TITLE
Resolve #661 Add Logarithmic scale option support on Y axis

### DIFF
--- a/chart_test.go
+++ b/chart_test.go
@@ -292,27 +292,27 @@ func TestChartWithLogarithmicBase(t *testing.T) {
 	assert.NoError(t, xlsx.AddChart(sheet1, "M1",
 		`{"type":"line","dimension":{"width":640, "height":480},`+
 			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
-			`"y_axis":{"scaling":{"logbase":10.5}},`+
+			`"y_axis":{"logbase":10.5},`+
 			`"title":{"name":"Line chart with log 10 scaling"}}`))
 	assert.NoError(t, xlsx.AddChart(sheet1, "A25",
 		`{"type":"line","dimension":{"width":320, "height":240},`+
 			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
-			`"y_axis":{"scaling":{"logbase":1.9}},`+
+			`"y_axis":{"logbase":1.9},`+
 			`"title":{"name":"Line chart with log 1.9 scaling"}}`))
 	assert.NoError(t, xlsx.AddChart(sheet1, "F25",
 		`{"type":"line","dimension":{"width":320, "height":240},`+
 			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
-			`"y_axis":{"scaling":{"logbase":2}},`+
+			`"y_axis":{"logbase":2},`+
 			`"title":{"name":"Line chart with log 2 scaling"}}`))
 	assert.NoError(t, xlsx.AddChart(sheet1, "K25",
 		`{"type":"line","dimension":{"width":320, "height":240},`+
 			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
-			`"y_axis":{"scaling":{"logbase":1000.1}},`+
+			`"y_axis":{"logbase":1000.1},`+
 			`"title":{"name":"Line chart with log 1000.1 scaling"}}`))
 	assert.NoError(t, xlsx.AddChart(sheet1, "P25",
 		`{"type":"line","dimension":{"width":320, "height":240},`+
 			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
-			`"y_axis":{"scaling":{"logbase":1000}},`+
+			`"y_axis":{"logbase":1000},`+
 			`"title":{"name":"Line chart with log 1000 scaling"}}`))
 
 	// Export XLSX file for human confirmation
@@ -356,6 +356,9 @@ func TestChartWithLogarithmicBase(t *testing.T) {
 				t.FailNow()
 			}
 		} else {
+			if !assert.NotNil(t, chartLogBasePtr, "LogBase is nil") {
+				t.FailNow()
+			}
 			if !assert.Equal(t, expectedChartsLogBase[i], *(chartLogBasePtr.Val),
 				"Expected log base to %f, actual %f", expectedChartsLogBase[i], *(chartLogBasePtr.Val)) {
 				t.FailNow()

--- a/chart_test.go
+++ b/chart_test.go
@@ -253,3 +253,113 @@ func TestDeleteChart(t *testing.T) {
 	// Test delete chart on no chart worksheet.
 	assert.NoError(t, NewFile().DeleteChart("Sheet1", "A1"))
 }
+
+func TestChartWithLogarithmicBase(t *testing.T) {
+	// Create test XLSX file with data
+	xlsx := NewFile()
+	sheet1 := xlsx.GetSheetName(0)
+	categories := map[string]float64{
+		"A1":  1,
+		"A2":  2,
+		"A3":  3,
+		"A4":  4,
+		"A5":  5,
+		"A6":  6,
+		"A7":  7,
+		"A8":  8,
+		"A9":  9,
+		"A10": 10,
+		"B1":  0.1,
+		"B2":  1,
+		"B3":  2,
+		"B4":  3,
+		"B5":  20,
+		"B6":  30,
+		"B7":  100,
+		"B8":  500,
+		"B9":  700,
+		"B10": 5000,
+	}
+	for cell, v := range categories {
+		assert.NoError(t, xlsx.SetCellValue(sheet1, cell, v))
+	}
+
+	// Add two chart, one without and one with log scaling
+	assert.NoError(t, xlsx.AddChart(sheet1, "C1",
+		`{"type":"line","dimension":{"width":640, "height":480},`+
+			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
+			`"title":{"name":"Line chart without log scaling"}}`))
+	assert.NoError(t, xlsx.AddChart(sheet1, "M1",
+		`{"type":"line","dimension":{"width":640, "height":480},`+
+			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
+			`"y_axis":{"scaling":{"logbase":10.5}},`+
+			`"title":{"name":"Line chart with log 10 scaling"}}`))
+	assert.NoError(t, xlsx.AddChart(sheet1, "A25",
+		`{"type":"line","dimension":{"width":320, "height":240},`+
+			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
+			`"y_axis":{"scaling":{"logbase":1.9}},`+
+			`"title":{"name":"Line chart with log 1.9 scaling"}}`))
+	assert.NoError(t, xlsx.AddChart(sheet1, "F25",
+		`{"type":"line","dimension":{"width":320, "height":240},`+
+			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
+			`"y_axis":{"scaling":{"logbase":2}},`+
+			`"title":{"name":"Line chart with log 2 scaling"}}`))
+	assert.NoError(t, xlsx.AddChart(sheet1, "K25",
+		`{"type":"line","dimension":{"width":320, "height":240},`+
+			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
+			`"y_axis":{"scaling":{"logbase":1000.1}},`+
+			`"title":{"name":"Line chart with log 1000.1 scaling"}}`))
+	assert.NoError(t, xlsx.AddChart(sheet1, "P25",
+		`{"type":"line","dimension":{"width":320, "height":240},`+
+			`"series":[{"name":"value","categories":"Sheet1!$A$1:$A$19","values":"Sheet1!$B$1:$B$10"}],`+
+			`"y_axis":{"scaling":{"logbase":1000}},`+
+			`"title":{"name":"Line chart with log 1000 scaling"}}`))
+
+	// Export XLSX file for human confirmation
+	assert.NoError(t, xlsx.SaveAs(filepath.Join("test", "TestChartWithLogarithmicBase10.xlsx")))
+
+	// Write the XLSX file to a buffer
+	var buffer bytes.Buffer
+	assert.NoError(t, xlsx.Write(&buffer))
+
+	// Read back the XLSX file from the buffer
+	newFile, err := OpenReader(&buffer)
+	assert.NoError(t, err)
+
+	// Check the number of charts
+	expectedChartsCount := 6
+	chartsNum := newFile.countCharts()
+	if !assert.Equal(t, expectedChartsCount, chartsNum,
+		"Expected %d charts, actual %d", expectedChartsCount, chartsNum) {
+		t.FailNow()
+	}
+
+	chartSpaces := make([]xlsxChartSpace, expectedChartsCount)
+	type xmlChartContent []byte
+	xmlCharts := make([]xmlChartContent, expectedChartsCount)
+	expectedChartsLogBase := []float64{0, 10.5, 0, 2, 0, 1000}
+	var ok bool
+
+	for i := 0; i < expectedChartsCount; i++ {
+		chartPath := fmt.Sprintf("xl/charts/chart%d.xml", i+1)
+		xmlCharts[i], ok = newFile.XLSX[chartPath]
+		assert.True(t, ok, "Can't open the %s", chartPath)
+
+		err = xml.Unmarshal([]byte(xmlCharts[i]), &chartSpaces[i])
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		chartLogBasePtr := chartSpaces[i].Chart.PlotArea.ValAx[0].Scaling.LogBase
+		if expectedChartsLogBase[i] == 0 {
+			if !assert.Nil(t, chartLogBasePtr, "LogBase is not nil") {
+				t.FailNow()
+			}
+		} else {
+			if !assert.Equal(t, expectedChartsLogBase[i], *(chartLogBasePtr.Val),
+				"Expected log base to %f, actual %f", expectedChartsLogBase[i], *(chartLogBasePtr.Val)) {
+				t.FailNow()
+			}
+		}
+	}
+}

--- a/drawing.go
+++ b/drawing.go
@@ -1000,9 +1000,11 @@ func (f *File) drawPlotAreaValAx(formatSet *formatChart) []*cAxs {
 	if formatSet.YAxis.Maximum == 0 {
 		max = nil
 	}
-	var logBase *attrValString
-	if formatSet.YAxis.Scaling.LogBase != "" {
-		logBase = &attrValString{Val: stringPtr(formatSet.YAxis.Scaling.LogBase)}
+	var logBase *attrValFloat
+	// Follow OOXML requirements on
+	// [https://github.com/sc34wg4/OOXMLSchemas/blob/2b074ca2c5df38b18ac118646b329b508b5bdecc/Part1/OfficeOpenXML-XMLSchema-Strict/dml-chart.xsd#L1142-L1147]
+	if formatSet.YAxis.Scaling.LogBase >= 2 && formatSet.YAxis.Scaling.LogBase <= 1000 {
+		logBase = &attrValFloat{Val: float64Ptr(formatSet.YAxis.Scaling.LogBase)}
 	}
 	axs := []*cAxs{
 		{

--- a/drawing.go
+++ b/drawing.go
@@ -1000,10 +1000,15 @@ func (f *File) drawPlotAreaValAx(formatSet *formatChart) []*cAxs {
 	if formatSet.YAxis.Maximum == 0 {
 		max = nil
 	}
+	var logBase *attrValString
+	if formatSet.YAxis.Scaling.LogBase != "" {
+		logBase = &attrValString{Val: stringPtr(formatSet.YAxis.Scaling.LogBase)}
+	}
 	axs := []*cAxs{
 		{
 			AxID: &attrValInt{Val: intPtr(753999904)},
 			Scaling: &cScaling{
+				LogBase:     logBase,
 				Orientation: &attrValString{Val: stringPtr(orientation[formatSet.YAxis.ReverseOrder])},
 				Max:         max,
 				Min:         min,

--- a/drawing.go
+++ b/drawing.go
@@ -1003,8 +1003,8 @@ func (f *File) drawPlotAreaValAx(formatSet *formatChart) []*cAxs {
 	var logBase *attrValFloat
 	// Follow OOXML requirements on
 	// [https://github.com/sc34wg4/OOXMLSchemas/blob/2b074ca2c5df38b18ac118646b329b508b5bdecc/Part1/OfficeOpenXML-XMLSchema-Strict/dml-chart.xsd#L1142-L1147]
-	if formatSet.YAxis.Scaling.LogBase >= 2 && formatSet.YAxis.Scaling.LogBase <= 1000 {
-		logBase = &attrValFloat{Val: float64Ptr(formatSet.YAxis.Scaling.LogBase)}
+	if formatSet.YAxis.LogBase >= 2 && formatSet.YAxis.LogBase <= 1000 {
+		logBase = &attrValFloat{Val: float64Ptr(formatSet.YAxis.LogBase)}
 	}
 	axs := []*cAxs{
 		{

--- a/xmlChart.go
+++ b/xmlChart.go
@@ -380,6 +380,7 @@ type cChartLines struct {
 // cScaling directly maps the scaling element. This element contains
 // additional axis settings.
 type cScaling struct {
+	LogBase     *attrValString `xml:"logBase"`
 	Orientation *attrValString `xml:"orientation"`
 	Max         *attrValFloat  `xml:"max"`
 	Min         *attrValFloat  `xml:"min"`
@@ -544,6 +545,9 @@ type formatChartAxis struct {
 		Italic    bool   `json:"italic"`
 		Underline bool   `json:"underline"`
 	} `json:"num_font"`
+	Scaling struct {
+		LogBase string `json:"logbase"`
+	} `json:"scaling"`
 	NameLayout formatLayout `json:"name_layout"`
 }
 

--- a/xmlChart.go
+++ b/xmlChart.go
@@ -545,9 +545,7 @@ type formatChartAxis struct {
 		Italic    bool   `json:"italic"`
 		Underline bool   `json:"underline"`
 	} `json:"num_font"`
-	Scaling struct {
-		LogBase float64 `json:"logbase"`
-	} `json:"scaling"`
+	LogBase    float64      `json:"logbase"`
 	NameLayout formatLayout `json:"name_layout"`
 }
 

--- a/xmlChart.go
+++ b/xmlChart.go
@@ -380,7 +380,7 @@ type cChartLines struct {
 // cScaling directly maps the scaling element. This element contains
 // additional axis settings.
 type cScaling struct {
-	LogBase     *attrValString `xml:"logBase"`
+	LogBase     *attrValFloat  `xml:"logBase"`
 	Orientation *attrValString `xml:"orientation"`
 	Max         *attrValFloat  `xml:"max"`
 	Min         *attrValFloat  `xml:"min"`
@@ -546,7 +546,7 @@ type formatChartAxis struct {
 		Underline bool   `json:"underline"`
 	} `json:"num_font"`
 	Scaling struct {
-		LogBase string `json:"logbase"`
+		LogBase float64 `json:"logbase"`
 	} `json:"scaling"`
 	NameLayout formatLayout `json:"name_layout"`
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Provide support for "Logarithmic scale option" on Y axis when drawing a chart.

## Description

<!--- Describe your changes in detail -->
1. Add member `LogBase` to the struct `cScaling` so that it will be generated in the final XML as follow:
```xml
<c:scaling>
    <c:logBase val="10"/>
    <c:orientation val="minMax"/>
</c:scaling>
```
2. Add `Scaling.LogBase` option in the `formatChartAxis` struct for the format string

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Add Logarithmic scale option support on Y axis #661

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Implement new feature

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Add the following option into the format string when using AddChart to add a 2D Line chart:
```json
"y_axis":{"scaling":{"logbase":10}}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
