### PR TITLE
Fix comment shape compatibility issue with the recent Excel versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 install:
-  - go get -d -t -v ./... && go build -v ./...
+  - env GO111MODULE=on go get -d -t -v ./... && go build -v ./...
 
 go:
   - 1.11.x
@@ -19,8 +19,8 @@ env:
     - GOARCH=386
 
 script:
-  - go vet ./...
-  - go test ./... -v -coverprofile=coverage.txt -covermode=atomic
+  - env GO111MODULE=on go vet ./...
+  - env GO111MODULE=on go test ./... -v -coverprofile=coverage.txt -covermode=atomic
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 install:
-  - env GO111MODULE=on go get -d -t -v ./... && go build -v ./...
+  - go get -d -t -v ./... && go build -v ./...
 
 go:
   - 1.11.x

--- a/comment.go
+++ b/comment.go
@@ -164,7 +164,7 @@ func (f *File) addDrawingVML(commentID int, drawingVML, cell string, lineCount, 
 				},
 				VPath: &vPath{
 					Gradientshapeok: "t",
-					Connecttype:     "miter",
+					Connecttype:     "rect",
 				},
 			},
 		}


### PR DESCRIPTION
# PR Details

Fix comment shape compatibility issue with the recent Excel versions

## Description

Change comment shape type v:path o:connecttype. To be honest I'm not sure about the root cause, but the fix seems to work.

## Related Issue

#672 

## Motivation and Context

Solve the issue above: When open files created by Excelize with comments, then save again, the comment shapes are changed by Excel.

## How Has This Been Tested

Manually on Mac OSX Catalina & Excel version 16.39

## Types of changes


- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
