### PR TITLE
Fix SetColStyle

### DIFF
--- a/col.go
+++ b/col.go
@@ -407,15 +407,19 @@ func (f *File) SetColStyle(sheet, columns string, styleID int) error {
 	if max < min {
 		min, max = max, min
 	}
-	if xlsx.Cols == nil {
-		xlsx.Cols = &xlsxCols{}
-	}
-	xlsx.Cols.Col = flatCols(xlsxCol{
+	col := xlsxCol{
 		Min:   min,
 		Max:   max,
 		Width: 9,
 		Style: styleID,
-	}, xlsx.Cols.Col, func(fc, c xlsxCol) xlsxCol {
+	}
+	if xlsx.Cols == nil {
+		cols := xlsxCols{}
+		cols.Col = append(cols.Col, col)
+		xlsx.Cols = &cols
+		return err
+	}
+	xlsx.Cols.Col = flatCols(col, xlsx.Cols.Col, func(fc, c xlsxCol) xlsxCol {
 		fc.BestFit = c.BestFit
 		fc.Collapsed = c.Collapsed
 		fc.CustomWidth = c.CustomWidth


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
SetColStyle was returning with no action when no columns were added
to the worksheet before.

## Description

<!--- Describe your changes in detail -->
This commit uses the same approach as the other col.go functions and
adds the columns to the worksheet if there are none.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#467 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes 467
Now if styles are added before any column it's present, they are not ignored.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unittests.
The test was failing before the fix, and it's passing now

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
