### PR TITLE
fix pivot fails in case of multi columns and multi data

### DIFF
--- a/pivotTable.go
+++ b/pivotTable.go
@@ -485,6 +485,13 @@ func (f *File) addPivotColFields(pt *xlsxPivotTableDefinition, opt *PivotTableOp
 		})
 	}
 
+	//in order to create pivot in case there is many Columns and Many Datas
+	if len(opt.Data) > 1 {
+		pt.ColFields.Field = append(pt.ColFields.Field, &xlsxField{
+			X: -2,
+		})
+	}
+
 	// count col fields
 	pt.ColFields.Count = len(pt.ColFields.Field)
 	return err

--- a/pivotTable_test.go
+++ b/pivotTable_test.go
@@ -135,6 +135,20 @@ func TestAddPivotTable(t *testing.T) {
 		ShowColHeaders:  true,
 		ShowLastColumn:  true,
 	}))
+	//Test Pivot table with many data, many rows, many cols
+	assert.NoError(t, f.AddPivotTable(&PivotTableOption{
+		DataRange:       "Sheet1!$A$1:$E$31",
+		PivotTableRange: "Sheet2!$A$56:$AG$90",
+		Rows:            []PivotTableField{{Data: "Month", DefaultSubtotal: true}, {Data: "Year"}},
+		Columns:         []PivotTableField{{Data: "Region", DefaultSubtotal: true}, {Data: "Type"}},
+		Data:            []PivotTableField{{Data: "Sales", Subtotal: "Sum", Name: "Sum of Sales"}, {Data: "Sales", Subtotal: "Average", Name: "Average of Sales"}},
+		RowGrandTotals:  true,
+		ColGrandTotals:  true,
+		ShowDrill:       true,
+		ShowRowHeaders:  true,
+		ShowColHeaders:  true,
+		ShowLastColumn:  true,
+	}))
 
 	// Test empty pivot table options
 	assert.EqualError(t, f.AddPivotTable(nil), "parameter is required")


### PR DESCRIPTION
# PR Details
 The pivot generation fails when pivot has many colums and many data.
 Please se details below. 
<!--- Provide a general summary of your changes in the Title above -->

## Description
i'll try to generate this pivot :
![image](https://user-images.githubusercontent.com/36153960/94713695-711ba600-034b-11eb-83fa-edae58f5a48b.png)

The database is this one : 

Month | Year | Type | Sales | Region
-- | -- | -- | -- | --
Jun | 2017 | Produce | 4059 | West
Jul | 2018 | Meat | 456 | East
Mar | 2018 | Beverages | 89 | East
Mar | 2017 | Dairy | 3237 | North
Dec | 2017 | Meat | 1258 | South
Aug | 2018 | Meat | 2790 | South
Feb | 2017 | Produce | 1831 | West
Sep | 2017 | Produce | 1485 | North
Feb | 2018 | Beverages | 563 | West
Apr | 2018 | Meat | 1159 | West
Oct | 2018 | Dairy | 2199 | East
Feb | 2019 | Beverages | 4703 | South
Dec | 2017 | Dairy | 156 | North
Sep | 2019 | Beverages | 4783 | North
Aug | 2017 | Beverages | 4718 | South
Jul | 2018 | Produce | 2996 | East
Apr | 2017 | Dairy | 3133 | West
Aug | 2019 | Produce | 3891 | North
Mar | 2018 | Beverages | 4107 | East
Aug | 2017 | Produce | 2205 | North
Oct | 2018 | Produce | 4757 | South
Mar | 2018 | Dairy | 3590 | East
Jul | 2018 | Produce | 3582 | East
Feb | 2019 | Dairy | 4271 | North
Mar | 2018 | Dairy | 2079 | North
Jul | 2019 | Beverages | 4819 | West
Jan | 2017 | Dairy | 710 | South
Feb | 2019 | Beverages | 4384 | South
Jan | 2019 | Meat | 1532 | East
Dec | 2019 | Beverages | 2051 | East

The code for this pivot is : 
```go
if err := f.AddPivotTable(&PivotTableOption{
		DataRange:       "Sheet1!$A$1:$E$31",
		PivotTableRange: "Sheet2!$A$56:$AG$90",
		Rows:            []PivotTableField{{Data: "Month", DefaultSubtotal: true}, {Data: "Year"}},
		Columns:         []PivotTableField{{Data: "Region", DefaultSubtotal: true}, {Data: "Type"}},
		Data:            []PivotTableField{{Data: "Sales", Subtotal: "Sum", Name: "Sum of Sales"}, {Data: "Sales", Subtotal: "Average", Name: "Average of Sales"}},
		RowGrandTotals:  true,
		ColGrandTotals:  true,
		ShowDrill:       true,
		ShowRowHeaders:  true,
		ShowColHeaders:  true,
		ShowLastColumn:  true,
	}); err != nil {
		fmt.Println(err)
	}
```
but this won't generate proper pivot table and end up with pivot table removed in the generated excel.

After doing comparison of "\xl\pivotTables\pivotTable1.xml",
the one that is working(generated manually) got colFields generated like,

```xml
<colFields count="4">
		<field x="5"/>
		<field x="6"/>
		<field x="7"/>
		<field x="-2"/>		 
</colFields>
```
The one by exelize is :

```xml
<colFields count="3">
		<field x="5"/>
		<field x="6"/>
		<field x="7"/>	 
</colFields>
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
go test TestAddPivotTable
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
