### PR TITLE
optimize memory allocation

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -206,8 +206,9 @@ func CoordinatesToCellName(col, row int) (string, error) {
 	if col < 1 || row < 1 {
 		return "", fmt.Errorf("invalid cell coordinates [%d, %d]", col, row)
 	}
+	//Using itoa will save more memory
 	colname, err := ColumnNumberToName(col)
-	return fmt.Sprintf("%s%d", colname, row), err
+	return colname + strconv.Itoa(row), err
 }
 
 // boolPtr returns a pointer to a bool with the given value.

--- a/sheet.go
+++ b/sheet.go
@@ -64,6 +64,19 @@ func (f *File) NewSheet(name string) int {
 	return f.GetSheetIndex(name)
 }
 
+// NewSheetWithRowNum provides the function to create a new sheet by given a worksheet and a given number of rows.
+// name and returns the index of the sheets in the workbook
+func (f *File) NewSheetWithRowNum(name string, rowNum int64) int {
+	num := f.NewSheet(name)
+
+	// pre alloc space;when we use this arr. will be not realloc mem.
+	if num > 0 {
+		xlsx, _ := f.workSheetReader(name)
+		xlsx.SheetData.Row = make([]xlsxRow, 0, rowNum)
+	}
+	return num
+}
+
 // contentTypesReader provides a function to get the pointer to the
 // [Content_Types].xml structure after deserialization.
 func (f *File) contentTypesReader() *xlsxTypes {

--- a/sheet.go
+++ b/sheet.go
@@ -64,19 +64,6 @@ func (f *File) NewSheet(name string) int {
 	return f.GetSheetIndex(name)
 }
 
-// NewSheetWithRowNum provides the function to create a new sheet by given a worksheet and a given number of rows.
-// name and returns the index of the sheets in the workbook
-func (f *File) NewSheetWithRowNum(name string, rowNum int64) int {
-	num := f.NewSheet(name)
-
-	// pre alloc space;when we use this arr. will be not realloc mem.
-	if num > 0 {
-		xlsx, _ := f.workSheetReader(name)
-		xlsx.SheetData.Row = make([]xlsxRow, 0, rowNum)
-	}
-	return num
-}
-
 // contentTypesReader provides a function to get the pointer to the
 // [Content_Types].xml structure after deserialization.
 func (f *File) contentTypesReader() *xlsxTypes {

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -3,6 +3,7 @@ package excelize
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -343,4 +344,56 @@ func TestSetSheetName(t *testing.T) {
 	// Test set workksheet with the same name.
 	f.SetSheetName("Sheet1", "Sheet1")
 	assert.Equal(t, "Sheet1", f.GetSheetName(0))
+}
+
+func BenchmarkNewSheetWithRowNum(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			newSheetWithRowNum()
+		}
+
+	})
+}
+func BenchmarkNewSheetWithRowNum1(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			newSheetWithOutRowNum()
+		}
+	})
+}
+func newSheetWithRowNum() {
+	file := NewFile()
+
+	file.NewSheetWithRowNum("sheet1", 1000)
+
+	for i := 0; i < 1000; i++ {
+		file.SetCellInt("sheet1", "A"+strconv.Itoa(i+1), i)
+	}
+	file = nil
+}
+func newSheetWithOutRowNum() {
+	file := NewFile()
+	file.NewSheet("sheet1")
+	for i := 0; i < 1000; i++ {
+		file.SetCellInt("sheet1", "A"+strconv.Itoa(i+1), i)
+	}
+	file = nil
+}
+
+func BenchmarkFile_SaveAs(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			newSheetWithSave()
+		}
+
+	})
+}
+
+func newSheetWithSave() {
+	file := NewFile()
+	file.NewSheet("sheet1")
+	for i := 0; i < 1000; i++ {
+		file.SetCellInt("sheet1", "A"+strconv.Itoa(i+1), i)
+	}
+	file.Save()
 }

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -346,6 +346,18 @@ func TestSetSheetName(t *testing.T) {
 	assert.Equal(t, "Sheet1", f.GetSheetName(0))
 }
 
+func TestNewSheetWithRowNum(t *testing.T) {
+	f := NewFile()
+	f.NewSheetWithRowNum("sheet1", 100)
+	f.SetCellInt("sheet1", "A100", 100)
+	val,err:=f.GetCellValue("sheet1", "A100")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t,"100",val)
+}
+
+
 func BenchmarkNewSheetWithRowNum(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -388,7 +400,6 @@ func BenchmarkFile_SaveAs(b *testing.B) {
 
 	})
 }
-
 func newSheetWithSave() {
 	file := NewFile()
 	file.NewSheet("sheet1")

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -350,13 +350,12 @@ func TestNewSheetWithRowNum(t *testing.T) {
 	f := NewFile()
 	f.NewSheetWithRowNum("sheet1", 100)
 	f.SetCellInt("sheet1", "A100", 100)
-	val,err:=f.GetCellValue("sheet1", "A100")
+	val, err := f.GetCellValue("sheet1", "A100")
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t,"100",val)
+	assert.Equal(t, "100", val)
 }
-
 
 func BenchmarkNewSheetWithRowNum(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
@@ -366,10 +365,17 @@ func BenchmarkNewSheetWithRowNum(b *testing.B) {
 
 	})
 }
-func BenchmarkNewSheetWithRowNum1(b *testing.B) {
+func BenchmarkNewSheetWithOutRowNum(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			newSheetWithOutRowNum()
+		}
+	})
+}
+func BenchmarkNewSheetWithStreamWriter(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			newSheetWithStreamWriter()
 		}
 	})
 }
@@ -390,6 +396,25 @@ func newSheetWithOutRowNum() {
 		file.SetCellInt("sheet1", "A"+strconv.Itoa(i+1), i)
 	}
 	file = nil
+}
+func newSheetWithStreamWriter() {
+	file := NewFile()
+	streamWriter, err := file.NewStreamWriter("Sheet1")
+	if err != nil {
+		fmt.Println(err)
+	}
+	for rowID := 1; rowID <= 1000; rowID++ {
+		cell, _ := CoordinatesToCellName(1, rowID)
+		if err := streamWriter.SetRow(cell, []interface{}{rowID}); err != nil {
+			fmt.Println(err)
+		}
+	}
+	if err := streamWriter.Flush(); err != nil {
+		fmt.Println(err)
+	}
+	if err := file.SaveAs("Book1.xlsx"); err != nil {
+		fmt.Println(err)
+	}
 }
 
 func BenchmarkFile_SaveAs(b *testing.B) {

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -346,75 +346,20 @@ func TestSetSheetName(t *testing.T) {
 	assert.Equal(t, "Sheet1", f.GetSheetName(0))
 }
 
-func TestNewSheetWithRowNum(t *testing.T) {
-	f := NewFile()
-	f.NewSheetWithRowNum("sheet1", 100)
-	f.SetCellInt("sheet1", "A100", 100)
-	val, err := f.GetCellValue("sheet1", "A100")
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, "100", val)
-}
-
-func BenchmarkNewSheetWithRowNum(b *testing.B) {
+func BenchmarkNewSheet(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			newSheetWithRowNum()
-		}
-
-	})
-}
-func BenchmarkNewSheetWithOutRowNum(b *testing.B) {
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			newSheetWithOutRowNum()
+			newSheetWithSet()
 		}
 	})
 }
-func BenchmarkNewSheetWithStreamWriter(b *testing.B) {
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			newSheetWithStreamWriter()
-		}
-	})
-}
-func newSheetWithRowNum() {
-	file := NewFile()
-
-	file.NewSheetWithRowNum("sheet1", 1000)
-
-	for i := 0; i < 1000; i++ {
-		file.SetCellInt("sheet1", "A"+strconv.Itoa(i+1), i)
-	}
-	file = nil
-}
-func newSheetWithOutRowNum() {
+func newSheetWithSet() {
 	file := NewFile()
 	file.NewSheet("sheet1")
 	for i := 0; i < 1000; i++ {
 		file.SetCellInt("sheet1", "A"+strconv.Itoa(i+1), i)
 	}
 	file = nil
-}
-func newSheetWithStreamWriter() {
-	file := NewFile()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
-	if err != nil {
-		fmt.Println(err)
-	}
-	for rowID := 1; rowID <= 1000; rowID++ {
-		cell, _ := CoordinatesToCellName(1, rowID)
-		if err := streamWriter.SetRow(cell, []interface{}{rowID}); err != nil {
-			fmt.Println(err)
-		}
-	}
-	if err := streamWriter.Flush(); err != nil {
-		fmt.Println(err)
-	}
-	if err := file.SaveAs("Book1.xlsx"); err != nil {
-		fmt.Println(err)
-	}
 }
 
 func BenchmarkFile_SaveAs(b *testing.B) {

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -313,20 +313,20 @@ type xlsxSheetData struct {
 // xlsxRow directly maps the row element. The element expresses information
 // about an entire row of a worksheet, and contains all cell definitions for a
 // particular row in the worksheet.
-type xlsxRow struct {
+type xlsxRow struct {	// alignment word
+	C            []xlsxC `xml:"c"`
+	Spans        string  `xml:"spans,attr,omitempty"`
+	Ht           float64 `xml:"ht,attr,omitempty"`
+	R            int     `xml:"r,attr,omitempty"`
+	S            int     `xml:"s,attr,omitempty"`
 	Collapsed    bool    `xml:"collapsed,attr,omitempty"`
 	CustomFormat bool    `xml:"customFormat,attr,omitempty"`
 	CustomHeight bool    `xml:"customHeight,attr,omitempty"`
 	Hidden       bool    `xml:"hidden,attr,omitempty"`
-	Ht           float64 `xml:"ht,attr,omitempty"`
 	OutlineLevel uint8   `xml:"outlineLevel,attr,omitempty"`
 	Ph           bool    `xml:"ph,attr,omitempty"`
-	R            int     `xml:"r,attr,omitempty"`
-	S            int     `xml:"s,attr,omitempty"`
-	Spans        string  `xml:"spans,attr,omitempty"`
 	ThickBot     bool    `xml:"thickBot,attr,omitempty"`
 	ThickTop     bool    `xml:"thickTop,attr,omitempty"`
-	C            []xlsxC `xml:"c"`
 }
 
 // xlsxSortState directly maps the sortState element. This collection
@@ -456,6 +456,7 @@ type DataValidation struct {
 //      s (Shared String)         | Cell containing a shared string.
 //      str (String)              | Cell containing a formula string.
 //
+// fixme: how to make this structure smaller; cur size is 152 bytes. it's be too bigger.
 type xlsxC struct {
 	XMLName  xml.Name `xml:"c"`
 	XMLSpace xml.Attr `xml:"space,attr,omitempty"`

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -315,18 +315,18 @@ type xlsxSheetData struct {
 // particular row in the worksheet.
 type xlsxRow struct {	// alignment word
 	C            []xlsxC `xml:"c"`
-	Spans        string  `xml:"spans,attr,omitempty"`
-	Ht           float64 `xml:"ht,attr,omitempty"`
 	R            int     `xml:"r,attr,omitempty"`
+	Spans        string  `xml:"spans,attr,omitempty"`
 	S            int     `xml:"s,attr,omitempty"`
-	Collapsed    bool    `xml:"collapsed,attr,omitempty"`
 	CustomFormat bool    `xml:"customFormat,attr,omitempty"`
-	CustomHeight bool    `xml:"customHeight,attr,omitempty"`
+	Ht           float64 `xml:"ht,attr,omitempty"`
 	Hidden       bool    `xml:"hidden,attr,omitempty"`
+	CustomHeight bool    `xml:"customHeight,attr,omitempty"`
 	OutlineLevel uint8   `xml:"outlineLevel,attr,omitempty"`
-	Ph           bool    `xml:"ph,attr,omitempty"`
-	ThickBot     bool    `xml:"thickBot,attr,omitempty"`
+	Collapsed    bool    `xml:"collapsed,attr,omitempty"`
 	ThickTop     bool    `xml:"thickTop,attr,omitempty"`
+	ThickBot     bool    `xml:"thickBot,attr,omitempty"`
+	Ph           bool    `xml:"ph,attr,omitempty"`
 }
 
 // xlsxSortState directly maps the sortState element. This collection


### PR DESCRIPTION
# PR Details

1.align xlsxRow struct.
2.optimization workSheetWriter
3. add NewSheetWithRowNum 

## Description

Mainly to optimize memory allocation

## Related Issue
l wish somebody can optimize xlsxC struct. it's too bigger.Maybe it can be optimized smaller.

## Motivation and Context

sometime l use this package. memory will alloc 500m ~ 1000m. it's too expensive

## How Has This Been Tested

```

go test -run=none -bench=BenchmarkNewSheetWithRowNum -benchmem -count 10

name                   old time/op    new time/op    delta
NewSheetWithRowNum1-8     667µs ± 5%     679µs ±15%     ~     (p=0.968 n=9+10)

name                   old alloc/op   new alloc/op   delta
NewSheetWithRowNum1-8     643kB ± 0%     588kB ± 0%   -8.46%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
NewSheetWithRowNum1-8     10.3k ± 0%      9.2k ± 0%  -10.68%  (p=0.000 n=10+10)


go test -run=none -bench=BenchmarkFile_SaveAs -benchmem -count 10
name           old time/op    new time/op    delta
File_SaveAs-8     738µs ±13%     698µs ±10%     ~     (p=0.105 n=10+10)

name           old alloc/op   new alloc/op   delta
File_SaveAs-8     643kB ± 0%     588kB ± 0%   -8.46%  (p=0.000 n=10+10)

name           old allocs/op  new allocs/op  delta
File_SaveAs-8     10.3k ± 0%      9.2k ± 0%  -10.67%  (p=0.000 n=9+10)



```



## Types of changes

- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
