### PR TITLE
value fields xlsxPatternFill.FgColor & xlsxPatternFill.BgColor cause …

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -2432,8 +2432,14 @@ func newFills(style *Style, fg bool) *xlsxFill {
 		var pattern xlsxPatternFill
 		pattern.PatternType = patterns[style.Fill.Pattern]
 		if fg {
+			if pattern.FgColor == nil {
+				pattern.FgColor = new(xlsxColor)
+			}
 			pattern.FgColor.RGB = getPaletteColor(style.Fill.Color[0])
 		} else {
+			if pattern.BgColor == nil {
+				pattern.BgColor = new(xlsxColor)
+			}
 			pattern.BgColor.RGB = getPaletteColor(style.Fill.Color[0])
 		}
 		fill.PatternFill = &pattern

--- a/xmlStyles.go
+++ b/xmlStyles.go
@@ -121,8 +121,8 @@ type xlsxFill struct {
 // specified by the bgColor element.
 type xlsxPatternFill struct {
 	PatternType string     `xml:"patternType,attr,omitempty"`
-	FgColor     *xlsxColor `xml:"fgColor,omitempty"`
-	BgColor     *xlsxColor `xml:"bgColor,omitempty"`
+	FgColor     *xlsxColor `xml:"fgColor"`
+	BgColor     *xlsxColor `xml:"bgColor"`
 }
 
 // xlsxGradientFill defines a gradient-style cell fill. Gradient cell fills can

--- a/xmlStyles.go
+++ b/xmlStyles.go
@@ -120,9 +120,9 @@ type xlsxFill struct {
 // For cell fills with patterns specified, then the cell fill color is
 // specified by the bgColor element.
 type xlsxPatternFill struct {
-	PatternType string    `xml:"patternType,attr,omitempty"`
-	FgColor     xlsxColor `xml:"fgColor,omitempty"`
-	BgColor     xlsxColor `xml:"bgColor,omitempty"`
+	PatternType string     `xml:"patternType,attr,omitempty"`
+	FgColor     *xlsxColor `xml:"fgColor,omitempty"`
+	BgColor     *xlsxColor `xml:"bgColor,omitempty"`
 }
 
 // xlsxGradientFill defines a gradient-style cell fill. Gradient cell fills can


### PR DESCRIPTION
Value fields `xlsxPatternFill.FgColor` & `xlsxPatternFill.BgColor` cause ineffective `omitempty` tags

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

`omitempty` tag is used at fields `xlsxPatternFill.FgColor` and `xlsxPatternFill.BgColor`, but they are both `value fields` but not `pointer fields`, which means they are not ignored while xml marshaling.

So I fixed it to `pointer fields`.

## Description

<!--- Describe your changes in detail -->

Below is defined at ECMA-376:

> ### 18.8.32 patternFill (Pattern)
>
> This element is used to specify cell fill information for pattern and solid color cell fills. For solid cell fills (no
pattern), fgColor is used. For cell fills with patterns specified, then the cell fill color is specified by the bgColor
element.


fgColor is used for solid cell, and fgColor is used for cell filled with color. 

Tag `omitempty` is used to ignore color elements not in need, where the `BgColor` and `FgColor` are both `value fields` but not `pointer fields`. It means blank xml element will be built.

sample in standard styles.xml:

```xml
<fill>
    <patternFill patternType="gray125"/>
</fill>
```

sample in excelize styles.xml:

```xml
<fill>
    <patternFill patternType="gray125">
        <fgColor></fgColor>
        <bgColor></bgColor>
    </patternFill>
</fill>
```

So what? Files with useless `color elements` may be not rendered normally in Google Sheets.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/360EntSecGroup-Skylar/excelize/issues/769

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```go
package main

import (
	"fmt"
	"strconv"

	"github.com/360EntSecGroup-Skylar/excelize/v2"
)

func main() {
	values := [][]string{
		{
			"1", "1", "1", "1",
		},
		{
			"1", "1", "1", "1",
		},
	}

	f := excelize.NewFile()

	// new sheet
	sheetName := "Sheet1"
	sheet := f.NewSheet(sheetName)

	// write data
	for i, row := range values {
		axis := "A" + strconv.FormatInt(int64(i+1), 10)

		f.SetSheetRow(sheetName, axis, &row)
	}

	// set color
	//
	// styleID, err := f.NewStyle(`{"fill":{"type":"pattern","pattern":1,"color":["#000000"]}}`)
	// if !assert.NoError(t, err) {
	// 	return
	// }
	// f.SetCellStyle("Sheet1", "A1", "B2", styleID)

	f.SetActiveSheet(sheet)

	// Save spreadsheet by the given path.
	if err := f.SaveAs("file.xlsx"); err != nil {
		fmt.Println(err)
	}
}
```

I wrote a sample code to build test xlsx files. Files built with new code work well in both Google Sheets and MS Office.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
