### PR TITLE
add GetCellRichText method and test

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -505,41 +505,38 @@ func (f *File) GetCellRichText(sheet, cell string) (runs []RichTextRun, err erro
 	if err != nil {
 		return
 	}
-
-	siIndex, err := strconv.Atoi(cellData.V)
+	siIdx, err := strconv.Atoi(cellData.V)
 	if nil != err {
 		return
 	}
-
 	sst := f.sharedStringsReader()
-	a := sst.SI[siIndex]
-	for _, v := range a.R {
+	if len(sst.SI) <= siIdx || siIdx < 0 {
+		return
+	}
+	si := sst.SI[siIdx]
+	for _, v := range si.R {
 		run := RichTextRun{
 			Text: v.T.Val,
 		}
 		if nil != v.RPr {
 			font := Font{}
-			font.Bold = v.RPr.B == " "
-			font.Italic = v.RPr.I == " "
+			font.Bold = v.RPr.B != nil
+			font.Italic = v.RPr.I != nil
 			if nil != v.RPr.U {
 				font.Underline = *v.RPr.U.Val
 			}
-
 			if nil != v.RPr.RFont {
 				font.Family = *v.RPr.RFont.Val
 			}
-
 			if nil != v.RPr.Sz {
 				font.Size = *v.RPr.Sz.Val
 			}
-
-			font.Strike = v.RPr.Strike == " "
+			font.Strike = v.RPr.Strike != nil
 			if nil != v.RPr.Color {
 				font.Color = strings.TrimPrefix(v.RPr.Color.RGB, "FF")
 			}
 			run.Font = &font
 		}
-
 		runs = append(runs, run)
 	}
 	return
@@ -670,14 +667,15 @@ func (f *File) SetCellRichText(sheet, cell string, runs []RichTextRun) error {
 		fnt := textRun.Font
 		if fnt != nil {
 			rpr := xlsxRPr{}
+			trueVal := ""
 			if fnt.Bold {
-				rpr.B = " "
+				rpr.B = &trueVal
 			}
 			if fnt.Italic {
-				rpr.I = " "
+				rpr.I = &trueVal
 			}
 			if fnt.Strike {
-				rpr.Strike = " "
+				rpr.Strike = &trueVal
 			}
 			if fnt.Underline != "" {
 				rpr.U = &attrValString{Val: &fnt.Underline}

--- a/comment.go
+++ b/comment.go
@@ -253,6 +253,7 @@ func (f *File) addComment(commentsXML, cell string, formatSet *formatComment) {
 		}
 	}
 	defaultFont := f.GetDefaultFont()
+	bold := ""
 	cmt := xlsxComment{
 		Ref:      cell,
 		AuthorID: 0,
@@ -260,7 +261,7 @@ func (f *File) addComment(commentsXML, cell string, formatSet *formatComment) {
 			R: []xlsxR{
 				{
 					RPr: &xlsxRPr{
-						B:  " ",
+						B:  &bold,
 						Sz: &attrValFloat{Val: float64Ptr(9)},
 						Color: &xlsxColor{
 							Indexed: 81,

--- a/xmlSharedStrings.go
+++ b/xmlSharedStrings.go
@@ -86,13 +86,13 @@ type xlsxRPr struct {
 	RFont     *attrValString `xml:"rFont"`
 	Charset   *attrValInt    `xml:"charset"`
 	Family    *attrValInt    `xml:"family"`
-	B         string         `xml:"b,omitempty"`
-	I         string         `xml:"i,omitempty"`
-	Strike    string         `xml:"strike,omitempty"`
-	Outline   string         `xml:"outline,omitempty"`
-	Shadow    string         `xml:"shadow,omitempty"`
-	Condense  string         `xml:"condense,omitempty"`
-	Extend    string         `xml:"extend,omitempty"`
+	B         *string        `xml:"b"`
+	I         *string        `xml:"i"`
+	Strike    *string        `xml:"strike"`
+	Outline   *string        `xml:"outline"`
+	Shadow    *string        `xml:"shadow"`
+	Condense  *string        `xml:"condense"`
+	Extend    *string        `xml:"extend"`
 	Color     *xlsxColor     `xml:"color"`
 	Sz        *attrValFloat  `xml:"sz"`
 	U         *attrValString `xml:"u"`


### PR DESCRIPTION
# GetCellRichText 

<!--- Provide a general summary of your changes in the Title above -->

## Description
You can get text and font of cell by use GetCellRichText
<!--- Describe your changes in detail -->
```go
        f := NewFile()

	runsSource := []RichTextRun{
		{
			Text: "a\n",
		},
		{
			Text: "b",
			Font: &Font{
				Underline: "single",
				Color:     "ff0000",
				Bold:      true,
				Italic:    true,
				Family:    "宋体",
				Size:      100,
				Strike:    true,
			},
		},
	}
	f.SetCellRichText("Sheet1", "A1", runsSource)

	runs, err := f.GetCellRichText("Sheet1", "A1")
```
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/360EntSecGroup-Skylar/excelize/issues/696

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
