### PR TITLE
Fix UpdateLinkedValue which returns an error when has graph sheet

### DIFF
--- a/chart_test.go
+++ b/chart_test.go
@@ -236,6 +236,8 @@ func TestAddChartSheet(t *testing.T) {
 	// Test with unsupported chart type
 	assert.EqualError(t, f.AddChartSheet("Chart2", `{"type":"unknown","series":[{"name":"Sheet1!$A$2","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$2:$D$2"},{"name":"Sheet1!$A$3","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$3:$D$3"},{"name":"Sheet1!$A$4","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$4:$D$4"}],"title":{"name":"Fruit 3D Clustered Column Chart"}}`), "unsupported chart type unknown")
 
+	assert.NoError(t, f.UpdateLinkedValue())
+
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestAddChartSheet.xlsx")))
 }
 

--- a/excelize_test.go
+++ b/excelize_test.go
@@ -1242,15 +1242,6 @@ func TestAttrValToInt(t *testing.T) {
 	assert.EqualError(t, err, `strconv.Atoi: parsing "s": invalid syntax`)
 }
 
-func TestUpdateLinkedValue(t *testing.T) {
-	// Test update the spreadsheet file.
-	f, err := OpenFile(filepath.Join("test", "TestGraphSheet.xlsx"))
-	assert.NoError(t, err)
-
-	// Test if have a graph sheet
-	assert.NoError(t, f.UpdateLinkedValue())
-}
-
 func prepareTestBook1() (*File, error) {
 	f, err := OpenFile(filepath.Join("test", "Book1.xlsx"))
 	if err != nil {

--- a/excelize_test.go
+++ b/excelize_test.go
@@ -1242,6 +1242,15 @@ func TestAttrValToInt(t *testing.T) {
 	assert.EqualError(t, err, `strconv.Atoi: parsing "s": invalid syntax`)
 }
 
+func TestUpdateLinkedValue(t *testing.T) {
+	// Test update the spreadsheet file.
+	f, err := OpenFile(filepath.Join("test", "TestGraphSheet.xlsx"))
+	assert.NoError(t, err)
+
+	// Test if have a graph sheet
+	assert.NoError(t, f.UpdateLinkedValue())
+}
+
 func prepareTestBook1() (*File, error) {
 	f, err := OpenFile(filepath.Join("test", "Book1.xlsx"))
 	if err != nil {


### PR DESCRIPTION
# PR Details
<!--- Provide a general summary of your changes in the Title above -->

If you create a graph sheet by the following procedure,
`UpdateLinkedValue` fails and no other sheets are recalculated.

(sorry for the Japanese page)
https://www.officepro.jp/excelgraph/init/index2.html#section1

![image](https://user-images.githubusercontent.com/1004620/109770629-21654180-7c3f-11eb-964c-041b40786f33.png)

## Description

Create a custom error `ChartSheetError` and
In `UpdateLinkedValue`, if `ChartSheetError` is returned from `workSheetReader`, it will not return.


## Related Issue

## Motivation and Context

## How Has This Been Tested

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
