### PR TITLE
Add support for setting hyperlink display & tooltip

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -431,6 +431,13 @@ func (f *File) GetCellHyperLink(sheet, axis string) (bool, string, error) {
 	return false, "", err
 }
 
+// HyperlinkOpts can be passed to SetCellHyperlink to set optional hyperlink
+// attributes (e.g. display value)
+type HyperlinkOpts struct {
+	Display *string
+	Tooltip *string
+}
+
 // SetCellHyperLink provides a function to set cell hyperlink by given
 // worksheet name and link URL address. LinkType defines two types of
 // hyperlink "External" for web site or "Location" for moving to one of cell
@@ -446,7 +453,7 @@ func (f *File) GetCellHyperLink(sheet, axis string) (bool, string, error) {
 //
 //    err := f.SetCellHyperLink("Sheet1", "A3", "Sheet1!A40", "Location")
 //
-func (f *File) SetCellHyperLink(sheet, axis, link, linkType string) error {
+func (f *File) SetCellHyperLink(sheet, axis, link, linkType string, opts ...HyperlinkOpts) error {
 	// Check for correct cell name
 	if _, _, err := SplitCellName(axis); err != nil {
 		return err
@@ -488,6 +495,15 @@ func (f *File) SetCellHyperLink(sheet, axis, link, linkType string) error {
 		}
 	default:
 		return fmt.Errorf("invalid link type %q", linkType)
+	}
+
+	for _, o := range opts {
+		if o.Display != nil {
+			linkData.Display = *o.Display
+		}
+		if o.Tooltip != nil {
+			linkData.Tooltip = *o.Tooltip
+		}
 	}
 
 	ws.Hyperlinks.Hyperlink = append(ws.Hyperlinks.Hyperlink, linkData)

--- a/excelize_test.go
+++ b/excelize_test.go
@@ -326,6 +326,13 @@ func TestSetCellHyperLink(t *testing.T) {
 	assert.NoError(t, f.SetCellHyperLink("Sheet2", "C1", "https://github.com/360EntSecGroup-Skylar/excelize", "External"))
 	// Test add Location hyperlink in a work sheet.
 	assert.NoError(t, f.SetCellHyperLink("Sheet2", "D6", "Sheet1!D8", "Location"))
+	// Test add Location hyperlink with display & tooltip in a work sheet.
+	display := "Display value"
+	tooltip := "Hover text"
+	assert.NoError(t, f.SetCellHyperLink("Sheet2", "D7", "Sheet1!D9", "Location", HyperlinkOpts{
+		Display: &display,
+		Tooltip: &tooltip,
+	}))
 
 	assert.EqualError(t, f.SetCellHyperLink("Sheet2", "C3", "Sheet1!D8", ""), `invalid link type ""`)
 

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -604,6 +604,7 @@ type xlsxHyperlink struct {
 	Ref      string `xml:"ref,attr"`
 	Location string `xml:"location,attr,omitempty"`
 	Display  string `xml:"display,attr,omitempty"`
+	Tooltip  string `xml:"tooltip,attr,omitempty"`
 	RID      string `xml:"http://schemas.openxmlformats.org/officeDocument/2006/relationships id,attr,omitempty"`
 }
 


### PR DESCRIPTION
# PR Details

## Description

Adds a new struct, `HyperlinkOpts`, that can be optionally passed to `SetCellHyperlink` to set the display or tooltip value of the hyperlink. This adds tooltip functionality, and adds the ability to set the display value for a hyperlink in Google Sheets.

## Related Issue

#790 

## Motivation and Context

Excel uses the cell value as the display value of a hyperlink, but Google Sheets relies on `display` being set correctly to set the display text. While Excel doesn't care about this value, it does correctly set it in the XML on save. Exposing the `display` attribute allows us to import excelize-generated spreadsheets into Google Sheets without breaking the link text of hyperlinks.

For completeness, I also added support for setting a Tooltip using the same `HyperlinkOpts` struct.

## How Has This Been Tested

I tested a simple case in Excel & Google Sheets:

```
locText := "location"
f.SetCellStr("Sheet1", "A1", "Location link text")
f.SetCellHyperLink(
	"Sheet1",
	"A1",
	"Sheet1!A5",
	"Location",
	excelize.HyperlinkOpts{Display: &locText, Tooltip: &locText},
)
```

In Excel, the current display behaviour remains (cell value is `Location link text`) and the tooltip text is `location`.

In Google Sheets, the cell value appears as `location` instead of falling back to the link location (e.g. `#gid=2039701591&range=A5`) and the tooltip is ignored (not supported in Sheets).

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
