### PR TITLE
support ShowError option in Pivot table

### DIFF
--- a/pivotTable.go
+++ b/pivotTable.go
@@ -34,6 +34,7 @@ type PivotTableOption struct {
 	PageOverThenDown    bool
 	MergeItem           bool
 	CompactData         bool
+	ShowError			bool
 	ShowRowHeaders      bool
 	ShowColHeaders      bool
 	ShowRowStripes      bool
@@ -308,6 +309,7 @@ func (f *File) addPivotTable(cacheID, pivotTableID int, pivotTableXML string, op
 		PageOverThenDown:  &opt.PageOverThenDown,
 		MergeItem:         &opt.MergeItem,
 		CompactData:       &opt.CompactData,
+		ShowError:         &opt.ShowError,
 		DataCaption:       "Values",
 		Location: &xlsxLocation{
 			Ref:            hcell + ":" + vcell,

--- a/pivotTable.go
+++ b/pivotTable.go
@@ -34,7 +34,7 @@ type PivotTableOption struct {
 	PageOverThenDown    bool
 	MergeItem           bool
 	CompactData         bool
-	ShowError			bool
+	ShowError           bool
 	ShowRowHeaders      bool
 	ShowColHeaders      bool
 	ShowRowStripes      bool

--- a/pivotTable_test.go
+++ b/pivotTable_test.go
@@ -38,6 +38,7 @@ func TestAddPivotTable(t *testing.T) {
 		ShowRowHeaders:  true,
 		ShowColHeaders:  true,
 		ShowLastColumn:  true,
+		ShowError:       true,
 	}))
 	// Use different order of coordinate tests
 	assert.NoError(t, f.AddPivotTable(&PivotTableOption{

--- a/xmlPivotTable.go
+++ b/xmlPivotTable.go
@@ -31,7 +31,7 @@ type xlsxPivotTableDefinition struct {
 	DataCaption             string                   `xml:"dataCaption,attr"`
 	GrandTotalCaption       string                   `xml:"grandTotalCaption,attr,omitempty"`
 	ErrorCaption            string                   `xml:"errorCaption,attr,omitempty"`
-	ShowError               bool                     `xml:"showError,attr,omitempty"`
+	ShowError               *bool                     `xml:"showError,attr,omitempty"`
 	MissingCaption          string                   `xml:"missingCaption,attr,omitempty"`
 	ShowMissing             bool                     `xml:"showMissing,attr,omitempty"`
 	PageStyle               string                   `xml:"pageStyle,attr,omitempty"`

--- a/xmlPivotTable.go
+++ b/xmlPivotTable.go
@@ -31,7 +31,7 @@ type xlsxPivotTableDefinition struct {
 	DataCaption             string                   `xml:"dataCaption,attr"`
 	GrandTotalCaption       string                   `xml:"grandTotalCaption,attr,omitempty"`
 	ErrorCaption            string                   `xml:"errorCaption,attr,omitempty"`
-	ShowError               *bool                     `xml:"showError,attr,omitempty"`
+	ShowError               *bool                    `xml:"showError,attr"`
 	MissingCaption          string                   `xml:"missingCaption,attr,omitempty"`
 	ShowMissing             bool                     `xml:"showMissing,attr,omitempty"`
 	PageStyle               string                   `xml:"pageStyle,attr,omitempty"`
@@ -48,7 +48,7 @@ type xlsxPivotTableDefinition struct {
 	VisualTotals            bool                     `xml:"visualTotals,attr,omitempty"`
 	ShowMultipleLabel       bool                     `xml:"showMultipleLabel,attr,omitempty"`
 	ShowDataDropDown        bool                     `xml:"showDataDropDown,attr,omitempty"`
-	ShowDrill               *bool                    `xml:"showDrill,attr,omitempty"`
+	ShowDrill               *bool                    `xml:"showDrill,attr"`
 	PrintDrill              bool                     `xml:"printDrill,attr,omitempty"`
 	ShowMemberPropertyTips  bool                     `xml:"showMemberPropertyTips,attr,omitempty"`
 	ShowDataTips            bool                     `xml:"showDataTips,attr,omitempty"`


### PR DESCRIPTION
# PR Details
This is a request to enable pivot table option. ShowError

<!--- Provide a general summary of your changes in the Title above -->

## Description
In Excel, PivotTable Options - Layout & Format - "For error values show"
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This Pivot table option allows to remove Error(#DIV/0!)
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
New option added into test file
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
