### PR TITLE
fix the bug that  there was no count attribute in   sharedStrings file, fix the bug  that setting OutlineSummaryBelow false

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -322,6 +322,9 @@ func (f *File) sharedStringsReader() *xlsxSST {
 			Decode(&sharedStrings); err != nil && err != io.EOF {
 			log.Printf("xml decode error: %s", err)
 		}
+		if sharedStrings.Count == 0 {
+			sharedStrings.Count = len(sharedStrings.SI)
+		}
 		if sharedStrings.UniqueCount == 0 {
 			sharedStrings.UniqueCount = sharedStrings.Count
 		}

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -248,9 +248,9 @@ type xlsxSheetPr struct {
 // adjust the direction of grouper controls.
 type xlsxOutlinePr struct {
 	ApplyStyles        *bool `xml:"applyStyles,attr"`
-	SummaryBelow       bool  `xml:"summaryBelow,attr,omitempty"`
-	SummaryRight       bool  `xml:"summaryRight,attr,omitempty"`
-	ShowOutlineSymbols bool  `xml:"showOutlineSymbols,attr,omitempty"`
+	SummaryBelow       bool  `xml:"summaryBelow,attr"`
+	SummaryRight       bool  `xml:"summaryRight,attr"`
+	ShowOutlineSymbols bool  `xml:"showOutlineSymbols,attr"`
 }
 
 // xlsxPageSetUpPr expresses page setup properties of the worksheet.


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
1. fix the inserting new string value bug  when there is no  Count attribute in  sharedStrings  file。
2. fix the bug  in  “f.SetSheetPrOptions(sheetname,excelize.OutlineSummaryBelow(false)) method”
  
## Description

<!--- Describe your changes in detail -->

1. According the  part 1 of the 5th edition of the ECMA-376 Standard for Office Open XML document , 18.4.9 page 1724,  the count  Attributes in sst(Shared String Table) is optional。when count  attributes is missing  in the sst and you want to insert a new string value  to  the cell  in the sheet , there is a bug that the cell value index  will start by 0 ,missing the former values in 
sst(Shared String Table).So I insert a logic calculate the count  of former values  when the count attribute is missing   to fix the bug.

2. According the  part 1 of the 5th edition of the ECMA-376 Standard for Office Open XML document 18.3.1.61 page 1653. and  the definition of outlinePr,  the  default values of  “showOutlineSymbols ”，“summaryBelow” ，“summaryRight” attributes are true. if you set those to false ,  the attribute will be gone and the behavior will be true because of the  “omitempty” in the tags and the default value. so i try to remove the "omitempty" in the tag.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
fixing two bugs.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
test local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
