### PR TITLE
feat: add disable option for chart xAxis and yAxis

### DIFF
--- a/drawing.go
+++ b/drawing.go
@@ -966,7 +966,7 @@ func (f *File) drawPlotAreaCatAx(formatSet *formatChart) []*cAxs {
 				Max:         max,
 				Min:         min,
 			},
-			Delete: &attrValBool{Val: boolPtr(false)},
+			Delete: &attrValBool{Val: boolPtr(formatSet.XAxis.None)},
 			AxPos:  &attrValString{Val: stringPtr(catAxPos[formatSet.XAxis.ReverseOrder])},
 			NumFmt: &cNumFmt{
 				FormatCode:   "General",
@@ -1020,7 +1020,7 @@ func (f *File) drawPlotAreaValAx(formatSet *formatChart) []*cAxs {
 				Max:         max,
 				Min:         min,
 			},
-			Delete: &attrValBool{Val: boolPtr(false)},
+			Delete: &attrValBool{Val: boolPtr(formatSet.YAxis.None)},
 			AxPos:  &attrValString{Val: stringPtr(valAxPos[formatSet.YAxis.ReverseOrder])},
 			NumFmt: &cNumFmt{
 				FormatCode:   chartValAxNumFmtFormatCode[formatSet.Type],
@@ -1069,7 +1069,7 @@ func (f *File) drawPlotAreaSerAx(formatSet *formatChart) []*cAxs {
 				Max:         max,
 				Min:         min,
 			},
-			Delete:     &attrValBool{Val: boolPtr(false)},
+			Delete:     &attrValBool{Val: boolPtr(formatSet.YAxis.None)},
 			AxPos:      &attrValString{Val: stringPtr(catAxPos[formatSet.XAxis.ReverseOrder])},
 			TickLblPos: &attrValString{Val: stringPtr("nextTo")},
 			SpPr:       f.drawPlotAreaSpPr(),

--- a/xmlChart.go
+++ b/xmlChart.go
@@ -520,6 +520,7 @@ type cPageMargins struct {
 
 // formatChartAxis directly maps the format settings of the chart axis.
 type formatChartAxis struct {
+	None                bool    `json:"none"`
 	Crossing            string  `json:"crossing"`
 	MajorGridlines      bool    `json:"major_grid_lines"`
 	MinorGridlines      bool    `json:"minor_grid_lines"`


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description
add disable option(none) for chart xAxis and yAxis

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/360EntSecGroup-Skylar/excelize/issues/850

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
add disable option(none) for chart xAxis and yAxis

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
