### PR TITLE
#409 Remove UTC timezone requirement from date.go

### DIFF
--- a/date.go
+++ b/date.go
@@ -30,13 +30,6 @@ var (
 func timeToExcelTime(t time.Time) (float64, error) {
 	// TODO in future this should probably also handle date1904 and like TimeFromExcelTime
 
-	// Force user to explicit convet passed value to UTC time.
-	// Because for example 1900-01-01 00:00:00 +0300 MSK converts to 1900-01-01 00:00:00 +0230 LMT
-	// probably due to daylight saving.
-	if t.Location() != time.UTC {
-		return 0.0, ErrToExcelTime
-	}
-
 	if t.Before(excelMinTime1900) {
 		return 0.0, nil
 	}

--- a/date_test.go
+++ b/date_test.go
@@ -55,7 +55,7 @@ func TestTimeToExcelTime_Timezone(t *testing.T) {
 	for i, test := range trueExpectedDateList {
 		t.Run(fmt.Sprintf("TestData%d", i+1), func(t *testing.T) {
 			_, err := timeToExcelTime(test.GoValue.In(location))
-			assert.EqualError(t, err, ErrToExcelTime.Error())
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/excelize_test.go
+++ b/excelize_test.go
@@ -144,7 +144,7 @@ func TestOpenFile(t *testing.T) {
 
 	assert.NoError(t, f.SetCellValue("Sheet2", "G2", nil))
 
-	assert.EqualError(t, f.SetCellValue("Sheet2", "G4", time.Now()), ErrToExcelTime.Error())
+	assert.NoError(t, f.SetCellValue("Sheet2", "G4", time.Now()))
 
 	assert.NoError(t, f.SetCellValue("Sheet2", "G4", time.Now().UTC()))
 	// 02:46:40

--- a/stream_test.go
+++ b/stream_test.go
@@ -57,7 +57,7 @@ func TestStreamWriter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, streamWriter.SetRow("A4", []interface{}{Cell{StyleID: styleID}, Cell{Formula: "SUM(A10,B10)"}}))
 	assert.NoError(t, streamWriter.SetRow("A5", []interface{}{&Cell{StyleID: styleID, Value: "cell"}, &Cell{Formula: "SUM(A10,B10)"}}))
-	assert.EqualError(t, streamWriter.SetRow("A6", []interface{}{time.Now()}), ErrToExcelTime.Error())
+	assert.NoError(t, streamWriter.SetRow("A6", []interface{}{time.Now()}))
 
 	for rowID := 10; rowID <= 51200; rowID++ {
 		row := make([]interface{}, 50)


### PR DESCRIPTION
According to issue #409

There is absolutely no reason for the timezone to be in UTC, and converting the local times to UTC while keeping values is hacky at least.

Excel has no understanding of timezones, hence the user of this library should know what timezone their values are supposed to be, by following the timezone within their timeTime structs.

There is no need for changes in documentation, as this requirement doesn't seem to be documented.

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
