### PR TITLE
feat: stream write to zip directly

### DIFF
--- a/file.go
+++ b/file.go
@@ -87,62 +87,29 @@ func (f *File) Write(w io.Writer) error {
 
 // WriteTo implements io.WriterTo to write the file.
 func (f *File) WriteTo(w io.Writer) (int64, error) {
-	buf, err := f.WriteToBuffer()
-	if err != nil {
+	if f.options != nil && f.options.Password != "" {
+		buf, err := f.WriteToBuffer()
+		if err != nil {
+			return 0, err
+		}
+		return buf.WriteTo(w)
+	}
+	if err := f.writeDirectToWriter(w); err != nil {
 		return 0, err
 	}
-	return buf.WriteTo(w)
+	return 0, nil
 }
 
 // WriteToBuffer provides a function to get bytes.Buffer from the saved file.
 func (f *File) WriteToBuffer() (*bytes.Buffer, error) {
 	buf := new(bytes.Buffer)
 	zw := zip.NewWriter(buf)
-	f.calcChainWriter()
-	f.commentsWriter()
-	f.contentTypesWriter()
-	f.drawingsWriter()
-	f.vmlDrawingWriter()
-	f.workBookWriter()
-	f.workSheetWriter()
-	f.relsWriter()
-	f.sharedStringsWriter()
-	f.styleSheetWriter()
 
-	for path, stream := range f.streams {
-		fi, err := zw.Create(path)
-		if err != nil {
-			zw.Close()
-			return buf, err
+	if err := f.writeToZip(zw); err != nil {
+		if e := zw.Close(); e != nil {
+			return buf, e
 		}
-		var from io.Reader
-		from, err = stream.rawData.Reader()
-		if err != nil {
-			stream.rawData.Close()
-			return buf, err
-		}
-		_, err = io.Copy(fi, from)
-		if err != nil {
-			zw.Close()
-			return buf, err
-		}
-		stream.rawData.Close()
-	}
-
-	for path, content := range f.XLSX {
-		if _, ok := f.streams[path]; ok {
-			continue
-		}
-		fi, err := zw.Create(path)
-		if err != nil {
-			zw.Close()
-			return buf, err
-		}
-		_, err = fi.Write(content)
-		if err != nil {
-			zw.Close()
-			return buf, err
-		}
+		return buf, err
 	}
 
 	if f.options != nil && f.options.Password != "" {
@@ -158,4 +125,62 @@ func (f *File) WriteToBuffer() (*bytes.Buffer, error) {
 		return buf, nil
 	}
 	return buf, zw.Close()
+}
+
+func (f *File) writeDirectToWriter(w io.Writer) error {
+	zw := zip.NewWriter(w)
+	if err := f.writeToZip(zw); err != nil {
+		if e := zw.Close(); e != nil {
+			return e
+		}
+		return err
+	}
+	return zw.Close()
+}
+
+func (f *File) writeToZip(zw *zip.Writer) error {
+	f.calcChainWriter()
+	f.commentsWriter()
+	f.contentTypesWriter()
+	f.drawingsWriter()
+	f.vmlDrawingWriter()
+	f.workBookWriter()
+	f.workSheetWriter()
+	f.relsWriter()
+	f.sharedStringsWriter()
+	f.styleSheetWriter()
+
+	for path, stream := range f.streams {
+		fi, err := zw.Create(path)
+		if err != nil {
+			return err
+		}
+		var from io.Reader
+		from, err = stream.rawData.Reader()
+		if err != nil {
+			stream.rawData.Close()
+			return err
+		}
+		_, err = io.Copy(fi, from)
+		if err != nil {
+			return err
+		}
+		stream.rawData.Close()
+	}
+
+	for path, content := range f.XLSX {
+		if _, ok := f.streams[path]; ok {
+			continue
+		}
+		fi, err := zw.Create(path)
+		if err != nil {
+			return err
+		}
+		_, err = fi.Write(content)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/file.go
+++ b/file.go
@@ -100,16 +100,13 @@ func (f *File) WriteTo(w io.Writer) (int64, error) {
 	return 0, nil
 }
 
-// WriteToBuffer provides a function to get bytes.Buffer from the saved file.
+// WriteToBuffer provides a function to get bytes.Buffer from the saved file. And it allocate space in memory. Be careful when the file size is large.
 func (f *File) WriteToBuffer() (*bytes.Buffer, error) {
 	buf := new(bytes.Buffer)
 	zw := zip.NewWriter(buf)
 
 	if err := f.writeToZip(zw); err != nil {
-		if e := zw.Close(); e != nil {
-			return buf, e
-		}
-		return buf, err
+		return buf, zw.Close()
 	}
 
 	if f.options != nil && f.options.Password != "" {
@@ -127,17 +124,17 @@ func (f *File) WriteToBuffer() (*bytes.Buffer, error) {
 	return buf, zw.Close()
 }
 
+// writeDirectToWriter provides a function to write to io.Writer.
 func (f *File) writeDirectToWriter(w io.Writer) error {
 	zw := zip.NewWriter(w)
 	if err := f.writeToZip(zw); err != nil {
-		if e := zw.Close(); e != nil {
-			return e
-		}
+		zw.Close()
 		return err
 	}
 	return zw.Close()
 }
 
+// writeToZip provides a function to write to zip.Writer
 func (f *File) writeToZip(zw *zip.Writer) error {
 	f.calcChainWriter()
 	f.commentsWriter()


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

Reduce the memory cost when saving file.

## Description

<!--- Describe your changes in detail -->

If options has set password, the process will write to buffer in memory. Or it will write directly to the file. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
