### PR TITLE
fix: LocalSheetID in DefinedName should be equal to SheetIndex insted of SheetID

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -507,17 +507,17 @@ func (f *File) DeleteSheet(name string) {
 	wb := f.workbookReader()
 	wbRels := f.relsReader(f.getWorkbookRelsPath())
 	activeSheetName := f.GetSheetName(f.GetActiveSheetIndex())
-	deleteSheetID := f.getSheetID(name)
+	deleteLocalSheetID := f.GetSheetIndex(name)
 	// Delete and adjust defined names
 	if wb.DefinedNames != nil {
 		for idx := 0; idx < len(wb.DefinedNames.DefinedName); idx++ {
 			dn := wb.DefinedNames.DefinedName[idx]
 			if dn.LocalSheetID != nil {
-				sheetID := *dn.LocalSheetID + 1
-				if sheetID == deleteSheetID {
+				localSheetID := *dn.LocalSheetID
+				if localSheetID == deleteLocalSheetID {
 					wb.DefinedNames.DefinedName = append(wb.DefinedNames.DefinedName[:idx], wb.DefinedNames.DefinedName[idx+1:]...)
 					idx--
-				} else if sheetID > deleteSheetID {
+				} else if localSheetID > deleteLocalSheetID {
 					wb.DefinedNames.DefinedName[idx].LocalSheetID = intPtr(*dn.LocalSheetID - 1)
 				}
 			}
@@ -1495,7 +1495,7 @@ func (f *File) SetDefinedName(definedName *DefinedName) error {
 		for _, dn := range wb.DefinedNames.DefinedName {
 			var scope string
 			if dn.LocalSheetID != nil {
-				scope = f.getSheetNameByID(*dn.LocalSheetID + 1)
+				scope = f.GetSheetName(*dn.LocalSheetID)
 			}
 			if scope == definedName.Scope && dn.Name == definedName.Name {
 				return errors.New("the same name already exists on the scope")
@@ -1525,7 +1525,7 @@ func (f *File) DeleteDefinedName(definedName *DefinedName) error {
 		for idx, dn := range wb.DefinedNames.DefinedName {
 			var scope string
 			if dn.LocalSheetID != nil {
-				scope = f.getSheetNameByID(*dn.LocalSheetID + 1)
+				scope = f.GetSheetName(*dn.LocalSheetID)
 			}
 			if scope == definedName.Scope && dn.Name == definedName.Name {
 				wb.DefinedNames.DefinedName = append(wb.DefinedNames.DefinedName[:idx], wb.DefinedNames.DefinedName[idx+1:]...)
@@ -1550,7 +1550,7 @@ func (f *File) GetDefinedName() []DefinedName {
 				Scope:    "Workbook",
 			}
 			if dn.LocalSheetID != nil && *dn.LocalSheetID >= 0 {
-				definedName.Scope = f.getSheetNameByID(*dn.LocalSheetID + 1)
+				definedName.Scope = f.GetSheetName(*dn.LocalSheetID)
 			}
 			definedNames = append(definedNames, definedName)
 		}


### PR DESCRIPTION
fix: LocalSheetID in DefinedName should be equal to SheetIndex instead of SheetID

# PR Details

Fixed the logic of the LocalSheetID field in DefinedName

## Description

The value of LocalSheetID must be equal to the sheet index, not to its SheetID

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
