### PR TITLE
Copy sheets across file(s)

### DIFF
--- a/excelize_test.go
+++ b/excelize_test.go
@@ -957,7 +957,7 @@ func TestCopySheetError(t *testing.T) {
 		t.FailNow()
 	}
 
-	assert.EqualError(t, f.copySheet(-1, -2), "sheet  is not exist")
+	assert.EqualError(t, f.copySheet(f, -1, -2), "sheet  is not exist")
 	if !assert.EqualError(t, f.CopySheet(-1, -2), "invalid worksheet index") {
 		t.FailNow()
 	}


### PR DESCRIPTION
# PR Details

This PR introduces a new method: `CopySheetFrom` allowing developers to copy sheets from one file to another. This method doesn't support copying workbooks that contain tables, charts, or pictures.

## Related Issue

This PR is related to a couple of Issues. There might be more issues related to this PR. Feel free to edit the description.

#818
#41

## Motivation and Context

There is currently no straight forward way to copy sheets across files.

## How Has This Been Tested

I have been testing this out using a couple of sample sheets by copying and cloning the first sheet called `template 1`.

```go
package main

import (
	excelize "github.com/360EntSecGroup-Skylar/excelize/v2"
)

func main() {
	f, _ := excelize.OpenFile("./template.xlsx")
	s, _ := excelize.OpenFile("./template.xlsx")

	f.CopySheetFrom(s, s.GetSheetIndex("template 1"), f.NewSheet("template 2"))
	f.SaveAs("./output.xlsx")
}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
